### PR TITLE
Fix: Separate public and private route groups for JWT middleware

### DIFF
--- a/backend/config/db.go
+++ b/backend/config/db.go
@@ -28,8 +28,8 @@ func SetupDatabase(database *gorm.DB) error {
 		&entity.MaintainLog{},
 		&entity.DeviceCredential{},
 	)
-	// seedGenders()
-	// seedPositions()
+	seedGenders(database)
+	seedPositions(database)
 	// seedRoles()
 	// seedUsers()
 	// seedLocations()
@@ -43,28 +43,28 @@ func SetupDatabase(database *gorm.DB) error {
 	return err
 }
 
-// func seedGenders() {
-// 	genders := []entity.Genders{
-// 		{Gender: "Male"},
-// 		{Gender: "Female"},
-// 		{Gender: "Other"},
-// 	}
-// 	for _, g := range genders {
-// 		db.FirstOrCreate(&g, entity.Genders{Gender: g.Gender})
-// 	}
-// }
+func seedGenders(database *gorm.DB) {
+	genders := []entity.Genders{
+		{Gender: "Male"},
+		{Gender: "Female"},
+		{Gender: "Other"},
+	}
+	for _, g := range genders {
+		database.FirstOrCreate(&g, entity.Genders{Gender: g.Gender})
+	}
+}
 
-// func seedPositions() map[string]entity.Position {
-// 	positions := []string{"Manager", "Engineer", "Technician", "Staff"}
-// 	posMap := make(map[string]entity.Position)
+func seedPositions(database *gorm.DB) map[string]entity.Position {
+	positions := []string{"Manager", "Engineer", "Technician", "Staff"}
+	posMap := make(map[string]entity.Position)
 
-// 	for _, name := range positions {
-// 		var p entity.Position
-// 		db.FirstOrCreate(&p, entity.Position{Position: name})
-// 		posMap[name] = p
-// 	}
-// 	return posMap
-// }
+	for _, name := range positions {
+		var p entity.Position
+		database.FirstOrCreate(&p, entity.Position{Position: name})
+		posMap[name] = p
+	}
+	return posMap
+}
 
 // func seedRoles() {
 // 	roles := []entity.Role{

--- a/backend/controller/users/auth_controller.go
+++ b/backend/controller/users/auth_controller.go
@@ -18,11 +18,17 @@ type AuthHandler struct {
 }
 
 // NewAuthHandler creates a new AuthHandler.
-func NewAuthHandler(authService services.AuthService) *AuthHandler {
-	return &AuthHandler{
+func NewAuthHandler(router *gin.RouterGroup, authService services.AuthService) *AuthHandler {
+	handler := &AuthHandler{
 		authService: authService,
 		validate:    validator.New(),
 	}
+
+	auth := router.Group("auth")
+	auth.POST("/register", handler.Register)
+	auth.POST("/login", handler.Login)
+
+	return handler
 }
 
 // Register creates a new user account.

--- a/backend/controller/users/user_controller.go
+++ b/backend/controller/users/user_controller.go
@@ -18,11 +18,20 @@ type UserHandler struct {
 }
 
 // NewUserHandler constructs a new UserHandler.
-func NewUserHandler(userService services.UserService) *UserHandler {
-	return &UserHandler{
+func NewUserHandler(router *gin.RouterGroup, userService services.UserService) *UserHandler {
+
+	handler := &UserHandler{
 		userService: userService,
 		validate:    validator.New(),
 	}
+
+	user := router.Group("users")
+	user.GET("", handler.GetAllUsers)
+	user.GET("/:id", handler.GetProfile)
+	user.PUT("/:id", handler.UpdateProfile)
+	user.DELETE("/:id", handler.DeleteUser)
+
+	return handler
 }
 
 // GetProfile returns the current user's profile.

--- a/backend/main.go
+++ b/backend/main.go
@@ -35,16 +35,21 @@ func main() {
 
 	router := r.Group("/api/v1")
 	router.Static("/uploads", "./uploads")
+
 	jwtProvider := utils.NewJWTProvider(c.JWTSecret, c.JWTExpiresIn)
 	userRepository := repositories.NewUserRepository(db)
 
 	authService := services.NewAuthService(userRepository, jwtProvider)
 	userService := services.NewUserService(userRepository)
 
-	users.NewAuthHandler(authService)
-	users.NewUserHandler(userService)
+	//puclice API
+	publicRouter := router.Group("")
+	users.NewAuthHandler(publicRouter, authService)
 
-	router.Use(middlewares.JWTAuthMiddleware())
+	//protect API
+	privateRouter := router.Group("")
+	privateRouter.Use(middlewares.JWTAuthMiddleware())
+	users.NewUserHandler(privateRouter, userService)
 
 	r.Run("localhost" + c.APIPort)
 }


### PR DESCRIPTION
- Created distinct router groups for public "auth" and private "users" endpoints.
- Applied JWT middleware exclusively to the private router to prevent it from blocking login and register routes.
- Organized endpoints logically within "NewAuthHandler" and "NewUserHandler".