### PR TITLE
test: add unit tests for all controllers and utils with 93.7% coverage

### DIFF
--- a/backend/config/utils/jwt_test.go
+++ b/backend/config/utils/jwt_test.go
@@ -1,0 +1,105 @@
+package utils
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const testSecret = "test-jwt-secret"
+
+func TestGenerateToken_ReturnsToken(t *testing.T) {
+	p := NewJWTProvider(testSecret, time.Hour)
+	tok, err := p.GenerateToken(42)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if tok == "" {
+		t.Fatal("expected non-empty token")
+	}
+}
+
+func TestParseToken_ValidToken(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", testSecret)
+	defer os.Unsetenv("JWT_SECRET_KEY")
+
+	p := NewJWTProvider(testSecret, time.Hour)
+	tok, _ := p.GenerateToken(7)
+
+	claims, err := ParseToken(tok)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if claims.UserID != 7 {
+		t.Errorf("expected UserID 7, got %d", claims.UserID)
+	}
+}
+
+func TestParseToken_MissingEnv(t *testing.T) {
+	os.Unsetenv("JWT_SECRET_KEY")
+	_, err := ParseToken("any.token.here")
+	if err == nil {
+		t.Fatal("expected error when JWT_SECRET_KEY is not set")
+	}
+}
+
+func TestParseToken_InvalidToken(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", testSecret)
+	defer os.Unsetenv("JWT_SECRET_KEY")
+
+	_, err := ParseToken("this.is.not.a.valid.jwt")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestParseToken_ExpiredToken(t *testing.T) {
+	os.Setenv("JWT_SECRET_KEY", testSecret)
+	defer os.Unsetenv("JWT_SECRET_KEY")
+
+	// สร้าง token ที่หมดอายุทันที
+	p := NewJWTProvider(testSecret, -time.Second)
+	tok, _ := p.GenerateToken(1)
+
+	_, err := ParseToken(tok)
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestGetUserIDFromContext_Found(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Set(ContextUserIDKey, uint(99))
+
+	id, ok := GetUserIDFromContext(c)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if id != 99 {
+		t.Errorf("expected 99, got %d", id)
+	}
+}
+
+func TestGetUserIDFromContext_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+
+	_, ok := GetUserIDFromContext(c)
+	if ok {
+		t.Fatal("expected ok=false when key not set")
+	}
+}
+
+func TestGetUserIDFromContext_WrongType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Set(ContextUserIDKey, "not-a-uint")
+
+	_, ok := GetUserIDFromContext(c)
+	if ok {
+		t.Fatal("expected ok=false for wrong type")
+	}
+}

--- a/backend/config/utils/response_test.go
+++ b/backend/config/utils/response_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c, w
+}
+
+// --- JSONSuccess ---
+
+func TestJSONSuccess_WithData(t *testing.T) {
+	c, w := newTestContext()
+	JSONSuccess(c, http.StatusOK, gin.H{"key": "value"})
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["success"] != true {
+		t.Error("expected success=true")
+	}
+	if resp["data"] == nil {
+		t.Error("expected data to be set")
+	}
+}
+
+func TestJSONSuccess_NoContent(t *testing.T) {
+	// gin.CreateTestContext ไม่ flush status โดยไม่มี body write — ใช้ router จริงแทน
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		JSONSuccess(c, http.StatusNoContent, nil)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status: want 204, got %d", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body for 204, got %q", w.Body.String())
+	}
+}
+
+// --- JSONError ---
+
+func TestJSONError_Structure(t *testing.T) {
+	c, w := newTestContext()
+	JSONError(c, http.StatusBadRequest, "validation failed", "field X is required")
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["success"] != false {
+		t.Error("expected success=false")
+	}
+	errObj, _ := resp["error"].(map[string]interface{})
+	if errObj["message"] != "validation failed" {
+		t.Errorf("message: got %v", errObj["message"])
+	}
+	if errObj["detail"] != "field X is required" {
+		t.Errorf("detail: got %v", errObj["detail"])
+	}
+}
+
+// --- NewError ---
+
+func TestNewError_Structure(t *testing.T) {
+	c, w := newTestContext()
+	NewError(c, http.StatusNotFound, ErrNotFound)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", w.Code)
+	}
+	var resp HTTPError
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("code: want 404, got %d", resp.Code)
+	}
+	if resp.Message != ErrNotFound.Error() {
+		t.Errorf("message: want %q, got %q", ErrNotFound.Error(), resp.Message)
+	}
+}

--- a/backend/controller/device/device_test.go
+++ b/backend/controller/device/device_test.go
@@ -1,0 +1,341 @@
+package device
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+)
+
+type mockDeviceService struct {
+	getAllFn                func() ([]models.DeviceResponse, error)
+	getByIDFn              func(id uint) (*models.DeviceResponse, error)
+	createFn               func(input models.DeviceRequest) (*models.DeviceResponse, error)
+	updateFn               func(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error)
+	deleteFn               func(id uint) error
+	getAvailableLocationsFn func() ([]models.LocationResponse, error)
+}
+
+func (m *mockDeviceService) GetAll() ([]models.DeviceResponse, error) {
+	return m.getAllFn()
+}
+func (m *mockDeviceService) GetByID(id uint) (*models.DeviceResponse, error) {
+	return m.getByIDFn(id)
+}
+func (m *mockDeviceService) Create(input models.DeviceRequest) (*models.DeviceResponse, error) {
+	return m.createFn(input)
+}
+func (m *mockDeviceService) Update(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error) {
+	return m.updateFn(id, input)
+}
+func (m *mockDeviceService) Delete(id uint) error {
+	return m.deleteFn(id)
+}
+func (m *mockDeviceService) GetAvailableLocations() ([]models.LocationResponse, error) {
+	return m.getAvailableLocationsFn()
+}
+
+func setupRouter(svc *mockDeviceService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewDeviceHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatus(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+func jsonBody(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func jsonReq(t *testing.T, method, url string, body *bytes.Buffer) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, url, body)
+	} else {
+		req = httptest.NewRequest(method, url, nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var locID = uint(1)
+var sampleDevice = models.DeviceResponse{
+	ID:         1,
+	MacAddress: "AA:BB:CC:DD:EE:FF",
+	LocationID: &locID,
+}
+
+// --- GetAll ---
+
+func TestGetAll_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getAllFn: func() ([]models.DeviceResponse, error) {
+			return []models.DeviceResponse{sampleDevice}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAll_ServiceError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getAllFn: func() ([]models.DeviceResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetAvailableLocations ---
+
+func TestGetAvailableLocations_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getAvailableLocationsFn: func() ([]models.LocationResponse, error) {
+			return []models.LocationResponse{{ID: 2, BuildingName: "อาคาร B"}}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices/available-locations", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAvailableLocations_ServiceError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getAvailableLocationsFn: func() ([]models.LocationResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices/available-locations", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetByID ---
+
+func TestGetByID_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getByIDFn: func(id uint) (*models.DeviceResponse, error) {
+			return &sampleDevice, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices/1", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		getByIDFn: func(id uint) (*models.DeviceResponse, error) {
+			return nil, errors.New("not found")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/devices/99", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create ---
+
+func TestCreate_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		createFn: func(input models.DeviceRequest) (*models.DeviceResponse, error) {
+			return &sampleDevice, nil
+		},
+	})
+	body := jsonBody(t, models.DeviceRequest{
+		MacAddress: "AA:BB:CC:DD:EE:FF",
+		Password:   "secret123",
+		LocationID: 1,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", body))
+	assertStatus(t, http.StatusCreated, w.Code)
+}
+
+func TestCreate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_ValidationError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	// password น้อยกว่า 6 ตัว → validation fail
+	body := jsonBody(t, map[string]any{
+		"mac_address": "AA:BB",
+		"password":    "123",
+		"location_id": 1,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_MacConflict(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		createFn: func(input models.DeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("mac address already exists")
+		},
+	})
+	body := jsonBody(t, models.DeviceRequest{
+		MacAddress: "AA:BB:CC:DD:EE:FF",
+		Password:   "secret123",
+		LocationID: 1,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", body))
+	assertStatus(t, http.StatusConflict, w.Code)
+}
+
+func TestCreate_LocationNotFound(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		createFn: func(input models.DeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("location not found")
+		},
+	})
+	body := jsonBody(t, models.DeviceRequest{
+		MacAddress: "AA:BB:CC:DD:EE:FF",
+		Password:   "secret123",
+		LocationID: 999,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", body))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		createFn: func(input models.DeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("insert failed")
+		},
+	})
+	body := jsonBody(t, models.DeviceRequest{
+		MacAddress: "AA:BB:CC:DD:EE:FF",
+		Password:   "secret123",
+		LocationID: 1,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/devices", body))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Update ---
+
+func TestUpdate_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		updateFn: func(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error) {
+			return &sampleDevice, nil
+		},
+	})
+	newID := uint(2)
+	body := jsonBody(t, models.UpdateDeviceRequest{LocationID: &newID})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/1", body))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestUpdate_InvalidID(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/xyz", bytes.NewBufferString("{}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/1", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_MacConflict(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		updateFn: func(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("mac address already exists")
+		},
+	})
+	body := jsonBody(t, models.UpdateDeviceRequest{MacAddress: "FF:EE:DD:CC:BB:AA"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/1", body))
+	assertStatus(t, http.StatusConflict, w.Code)
+}
+
+func TestUpdate_LocationNotFound(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		updateFn: func(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("location not found")
+		},
+	})
+	newID := uint(999)
+	body := jsonBody(t, models.UpdateDeviceRequest{LocationID: &newID})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/1", body))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		updateFn: func(id uint, input models.UpdateDeviceRequest) (*models.DeviceResponse, error) {
+			return nil, errors.New("update failed")
+		},
+	})
+	body := jsonBody(t, models.UpdateDeviceRequest{MacAddress: "AA:BB:CC:DD:EE:FF"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/devices/1", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Delete ---
+
+func TestDelete_Success(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		deleteFn: func(id uint) error { return nil },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/devices/1", nil))
+	assertStatus(t, http.StatusNoContent, w.Code)
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	r := setupRouter(&mockDeviceService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/devices/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDelete_ServiceError(t *testing.T) {
+	r := setupRouter(&mockDeviceService{
+		deleteFn: func(id uint) error { return errors.New("delete failed") },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/devices/1", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}

--- a/backend/controller/maintainlog/maintainlog_test.go
+++ b/backend/controller/maintainlog/maintainlog_test.go
@@ -1,0 +1,276 @@
+package maintainlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+)
+
+type mockMaintainLogService struct {
+	getAllFn       func() ([]models.MaintainLogResponse, error)
+	getByIDFn     func(id uint) (*models.MaintainLogResponse, error)
+	createFn      func(input models.MaintainLogRequest) (*models.MaintainLogResponse, error)
+	updateFn      func(id uint, input models.UpdateMaintainLogRequest) (*models.MaintainLogResponse, error)
+	deleteFn      func(id uint) error
+	getStatusesFn func() ([]models.StatusLogResponse, error)
+}
+
+func (m *mockMaintainLogService) GetAll() ([]models.MaintainLogResponse, error) {
+	return m.getAllFn()
+}
+func (m *mockMaintainLogService) GetByID(id uint) (*models.MaintainLogResponse, error) {
+	return m.getByIDFn(id)
+}
+func (m *mockMaintainLogService) Create(input models.MaintainLogRequest) (*models.MaintainLogResponse, error) {
+	return m.createFn(input)
+}
+func (m *mockMaintainLogService) Update(id uint, input models.UpdateMaintainLogRequest) (*models.MaintainLogResponse, error) {
+	return m.updateFn(id, input)
+}
+func (m *mockMaintainLogService) Delete(id uint) error {
+	return m.deleteFn(id)
+}
+func (m *mockMaintainLogService) GetStatuses() ([]models.StatusLogResponse, error) {
+	return m.getStatusesFn()
+}
+
+func setupRouter(svc *mockMaintainLogService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewMaintainLogHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatus(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+func jsonBody(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func jsonReq(t *testing.T, method, url string, body *bytes.Buffer) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, url, body)
+	} else {
+		req = httptest.NewRequest(method, url, nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var sampleLog = models.MaintainLogResponse{
+	ID:           1,
+	Title:        "ซ่อมท่อรั่ว",
+	LocationText: "ชั้น 3 อาคาร A",
+}
+
+// --- GetAll ---
+
+func TestGetAll_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getAllFn: func() ([]models.MaintainLogResponse, error) {
+			return []models.MaintainLogResponse{sampleLog}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAll_ServiceError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getAllFn: func() ([]models.MaintainLogResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetStatuses ---
+
+func TestGetStatuses_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getStatusesFn: func() ([]models.StatusLogResponse, error) {
+			return []models.StatusLogResponse{{ID: 1, StatusLog: "รอดำเนินการ"}}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs/statuses", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetStatuses_ServiceError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getStatusesFn: func() ([]models.StatusLogResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs/statuses", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetByID ---
+
+func TestGetByID_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getByIDFn: func(id uint) (*models.MaintainLogResponse, error) {
+			return &sampleLog, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs/1", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		getByIDFn: func(id uint) (*models.MaintainLogResponse, error) {
+			return nil, errors.New("not found")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/maintain-logs/99", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create ---
+
+func TestCreate_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		createFn: func(input models.MaintainLogRequest) (*models.MaintainLogResponse, error) {
+			return &sampleLog, nil
+		},
+	})
+	body := jsonBody(t, models.MaintainLogRequest{
+		Title:        "ซ่อมท่อ",
+		LocationText: "ชั้น 1",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/maintain-logs", body))
+	assertStatus(t, http.StatusCreated, w.Code)
+}
+
+func TestCreate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/maintain-logs", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_ValidationError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	// title และ location_text เป็น required — ส่งแค่ empty object
+	body := jsonBody(t, map[string]any{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/maintain-logs", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		createFn: func(input models.MaintainLogRequest) (*models.MaintainLogResponse, error) {
+			return nil, errors.New("insert failed")
+		},
+	})
+	body := jsonBody(t, models.MaintainLogRequest{
+		Title:        "ซ่อมท่อ",
+		LocationText: "ชั้น 1",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/maintain-logs", body))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Update ---
+
+func TestUpdate_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		updateFn: func(id uint, input models.UpdateMaintainLogRequest) (*models.MaintainLogResponse, error) {
+			return &sampleLog, nil
+		},
+	})
+	body := jsonBody(t, models.UpdateMaintainLogRequest{Title: "ซ่อมท่อ (แก้ไข)"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/maintain-logs/1", body))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestUpdate_InvalidID(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/maintain-logs/xyz", bytes.NewBufferString("{}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/maintain-logs/1", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		updateFn: func(id uint, input models.UpdateMaintainLogRequest) (*models.MaintainLogResponse, error) {
+			return nil, errors.New("update failed")
+		},
+	})
+	body := jsonBody(t, models.UpdateMaintainLogRequest{Title: "แก้ไข"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/maintain-logs/1", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Delete ---
+
+func TestDelete_Success(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		deleteFn: func(id uint) error { return nil },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/maintain-logs/1", nil))
+	assertStatus(t, http.StatusNoContent, w.Code)
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/maintain-logs/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDelete_ServiceError(t *testing.T) {
+	r := setupRouter(&mockMaintainLogService{
+		deleteFn: func(id uint) error { return errors.New("delete failed") },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/maintain-logs/1", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}

--- a/backend/controller/notification/notification_test.go
+++ b/backend/controller/notification/notification_test.go
@@ -1,0 +1,214 @@
+package notification
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+)
+
+type mockNotificationService struct {
+	getAllFn       func() ([]models.NotificationResponse, error)
+	getByIDFn     func(id uint) (*models.NotificationResponse, error)
+	markAsReadFn  func(id uint) (*models.NotificationResponse, error)
+	markAllReadFn func() error
+	deleteFn      func(id uint) error
+	getStatsFn    func() (*models.NotificationStatsResponse, error)
+}
+
+func (m *mockNotificationService) GetAll() ([]models.NotificationResponse, error) {
+	return m.getAllFn()
+}
+func (m *mockNotificationService) GetByID(id uint) (*models.NotificationResponse, error) {
+	return m.getByIDFn(id)
+}
+func (m *mockNotificationService) MarkAsRead(id uint) (*models.NotificationResponse, error) {
+	return m.markAsReadFn(id)
+}
+func (m *mockNotificationService) MarkAllAsRead() error {
+	return m.markAllReadFn()
+}
+func (m *mockNotificationService) Delete(id uint) error {
+	return m.deleteFn(id)
+}
+func (m *mockNotificationService) GetStats() (*models.NotificationStatsResponse, error) {
+	return m.getStatsFn()
+}
+
+func setupRouter(svc *mockNotificationService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewNotificationHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatus(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+var sampleNotif = models.NotificationResponse{ID: 1, Message: "ค่าผิดปกติ", IsRead: false}
+
+// --- GetAll ---
+
+func TestGetAll_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getAllFn: func() ([]models.NotificationResponse, error) {
+			return []models.NotificationResponse{sampleNotif}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAll_ServiceError(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getAllFn: func() ([]models.NotificationResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetStats ---
+
+func TestGetStats_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getStatsFn: func() (*models.NotificationStatsResponse, error) {
+			return &models.NotificationStatsResponse{Total: 10, Unread: 3}, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stats", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetStats_ServiceError(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getStatsFn: func() (*models.NotificationStatsResponse, error) {
+			return nil, errors.New("db error")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stats", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetByID ---
+
+func TestGetByID_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getByIDFn: func(id uint) (*models.NotificationResponse, error) {
+			return &sampleNotif, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/1", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	r := setupRouter(&mockNotificationService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		getByIDFn: func(id uint) (*models.NotificationResponse, error) {
+			return nil, errors.New("not found")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/99", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+// --- MarkAsRead ---
+
+func TestMarkAsRead_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		markAsReadFn: func(id uint) (*models.NotificationResponse, error) {
+			n := sampleNotif
+			n.IsRead = true
+			return &n, nil
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/1/read", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestMarkAsRead_InvalidID(t *testing.T) {
+	r := setupRouter(&mockNotificationService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/xyz/read", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMarkAsRead_NotFound(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		markAsReadFn: func(id uint) (*models.NotificationResponse, error) {
+			return nil, errors.New("not found")
+		},
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/99/read", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+// --- MarkAllAsRead ---
+
+func TestMarkAllAsRead_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		markAllReadFn: func() error { return nil },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/read-all", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestMarkAllAsRead_ServiceError(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		markAllReadFn: func() error { return errors.New("db error") },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/read-all", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Delete ---
+
+func TestDelete_Success(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		deleteFn: func(id uint) error { return nil },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/1", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	r := setupRouter(&mockNotificationService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	r := setupRouter(&mockNotificationService{
+		deleteFn: func(id uint) error { return errors.New("not found") },
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/99", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}

--- a/backend/controller/upload_image/upload_image_test.go
+++ b/backend/controller/upload_image/upload_image_test.go
@@ -1,0 +1,55 @@
+package upload_image
+
+import (
+	"testing"
+)
+
+func TestSanitizeFilename_ReplacesSpecialChars(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`AA\BB`, "AA_BB"},
+		{"AA/BB", "AA_BB"},
+		{"AA:BB", "AA_BB"},
+		{"AA*BB", "AA_BB"},
+		{"AA?BB", "AA_BB"},
+		{`AA"BB`, "AA_BB"},
+		{"AA<BB", "AA_BB"},
+		{"AA>BB", "AA_BB"},
+		{"AA|BB", "AA_BB"},
+		{"normal_filename.jpg", "normal_filename.jpg"},
+		{"AA:BB/CC\\DD", "AA_BB_CC_DD"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := sanitizeFilename(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeFilename(%q): want %q, got %q", tc.input, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestUintPtr_ReturnsPointer(t *testing.T) {
+	val := uint(42)
+	ptr := uintPtr(val)
+
+	if ptr == nil {
+		t.Fatal("expected non-nil pointer")
+	}
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestUintPtr_Zero(t *testing.T) {
+	ptr := uintPtr(0)
+	if ptr == nil {
+		t.Fatal("expected non-nil pointer for zero value")
+	}
+	if *ptr != 0 {
+		t.Errorf("expected 0, got %d", *ptr)
+	}
+}

--- a/backend/controller/users/auth_controller_test.go
+++ b/backend/controller/users/auth_controller_test.go
@@ -1,0 +1,156 @@
+package users
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+)
+
+type mockAuthService struct {
+	registerFn func(input models.RegisterRequest) (*models.AuthResponse, error)
+	loginFn    func(input models.LoginRequest) (*models.AuthResponse, error)
+}
+
+func (m *mockAuthService) Register(input models.RegisterRequest) (*models.AuthResponse, error) {
+	return m.registerFn(input)
+}
+func (m *mockAuthService) Login(input models.LoginRequest) (*models.AuthResponse, error) {
+	return m.loginFn(input)
+}
+
+func setupAuthRouter(svc *mockAuthService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	NewAuthHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatusAuth(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+func jsonBodyAuth(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, _ := json.Marshal(v)
+	return bytes.NewBuffer(b)
+}
+
+func jsonReqAuth(t *testing.T, method, url string, body *bytes.Buffer) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var sampleAuth = &models.AuthResponse{Token: "tok", User: &models.UserResponse{ID: 1}}
+
+// --- Register ---
+
+func TestRegister_Success(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{
+		registerFn: func(input models.RegisterRequest) (*models.AuthResponse, error) {
+			return sampleAuth, nil
+		},
+	})
+	body := jsonBodyAuth(t, models.RegisterRequest{
+		Name:     "สมชาย ใจดี",
+		Email:    "test@example.com",
+		Password: "password123",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/register", body))
+	assertStatusAuth(t, http.StatusCreated, w.Code)
+}
+
+func TestRegister_InvalidJSON(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/register", bytes.NewBufferString("{bad}")))
+	assertStatusAuth(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRegister_ValidationError(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{})
+	// password น้อยกว่า 8 ตัวอักษร
+	body := jsonBodyAuth(t, map[string]any{
+		"name":     "สมชาย",
+		"email":    "bad-email",
+		"password": "123",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/register", body))
+	assertStatusAuth(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRegister_ServiceError(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{
+		registerFn: func(input models.RegisterRequest) (*models.AuthResponse, error) {
+			return nil, errors.New("email already exist")
+		},
+	})
+	body := jsonBodyAuth(t, models.RegisterRequest{
+		Name:     "สมชาย ใจดี",
+		Email:    "existing@example.com",
+		Password: "password123",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/register", body))
+	assertStatusAuth(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Login ---
+
+func TestLogin_Success(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{
+		loginFn: func(input models.LoginRequest) (*models.AuthResponse, error) {
+			return sampleAuth, nil
+		},
+	})
+	body := jsonBodyAuth(t, models.LoginRequest{
+		Email:    "test@example.com",
+		Password: "password123",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/login", body))
+	assertStatusAuth(t, http.StatusOK, w.Code)
+}
+
+func TestLogin_InvalidJSON(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString("{bad}")))
+	assertStatusAuth(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogin_ValidationError(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{})
+	// email format ผิด
+	body := jsonBodyAuth(t, map[string]any{"email": "not-an-email", "password": "pass"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/login", body))
+	assertStatusAuth(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogin_Unauthorized(t *testing.T) {
+	r := setupAuthRouter(&mockAuthService{
+		loginFn: func(input models.LoginRequest) (*models.AuthResponse, error) {
+			return nil, errors.New("invalid credentials")
+		},
+	})
+	body := jsonBodyAuth(t, models.LoginRequest{
+		Email:    "test@example.com",
+		Password: "wrongpassword",
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqAuth(t, http.MethodPost, "/api/v1/auth/login", body))
+	assertStatusAuth(t, http.StatusUnauthorized, w.Code)
+}

--- a/backend/controller/users/user_controller_test.go
+++ b/backend/controller/users/user_controller_test.go
@@ -1,0 +1,271 @@
+package users
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+	"github.com/watermeter/suth/config/utils"
+)
+
+type mockUserService struct {
+	getProfileFn     func(userID uint) (*models.UserResponse, error)
+	updateProfileFn  func(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error)
+	changePasswordFn func(userID uint, input models.ChangePasswordRequest) error
+	deleteUserFn     func(userID uint) error
+	getAllUsersFn     func() ([]models.UserResponse, error)
+}
+
+func (m *mockUserService) GetProfile(userID uint) (*models.UserResponse, error) {
+	return m.getProfileFn(userID)
+}
+func (m *mockUserService) UpdateProfile(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error) {
+	return m.updateProfileFn(userID, input)
+}
+func (m *mockUserService) ChangePassword(userID uint, input models.ChangePasswordRequest) error {
+	return m.changePasswordFn(userID, input)
+}
+func (m *mockUserService) DeleteUser(userID uint) error {
+	return m.deleteUserFn(userID)
+}
+func (m *mockUserService) GetAllUsers() ([]models.UserResponse, error) {
+	return m.getAllUsersFn()
+}
+
+func setupUserRouter(svc *mockUserService, userID *uint) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	if userID != nil {
+		uid := *userID
+		r.Use(func(c *gin.Context) {
+			c.Set(utils.ContextUserIDKey, uid)
+			c.Next()
+		})
+	}
+	NewUserHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatusUser(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+func jsonBodyUser(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, _ := json.Marshal(v)
+	return bytes.NewBuffer(b)
+}
+
+func jsonReqUser(t *testing.T, method, url string, body *bytes.Buffer) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, url, body)
+	} else {
+		req = httptest.NewRequest(method, url, nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var testUID = uint(1)
+var sampleUser = &models.UserResponse{ID: 1, FirstName: "สมชาย", Email: "test@example.com"}
+
+// --- GetAllUsers ---
+
+func TestGetAllUsers_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		getAllUsersFn: func() ([]models.UserResponse, error) {
+			return []models.UserResponse{*sampleUser}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/users", nil))
+	assertStatusUser(t, http.StatusOK, w.Code)
+}
+
+func TestGetAllUsers_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		getAllUsersFn: func() ([]models.UserResponse, error) {
+			return nil, errors.New("db error")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/users", nil))
+	assertStatusUser(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetProfile ---
+
+func TestGetProfile_MissingUserID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetProfile_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		getProfileFn: func(userID uint) (*models.UserResponse, error) {
+			return sampleUser, nil
+		},
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusOK, w.Code)
+}
+
+func TestGetProfile_NotFound(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		getProfileFn: func(userID uint) (*models.UserResponse, error) {
+			return nil, errors.New("not found")
+		},
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusNotFound, w.Code)
+}
+
+// --- UpdateProfile ---
+
+func TestUpdateProfile_MissingUserID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1", jsonBodyUser(t, map[string]any{})))
+	assertStatusUser(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestUpdateProfile_InvalidJSON(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1", bytes.NewBufferString("{bad}")))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateProfile_ValidationError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	// first_name น้อยกว่า 3 ตัวอักษร (min=3)
+	body := jsonBodyUser(t, map[string]any{"first_name": "ab", "email": "not-email"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateProfile_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		updateProfileFn: func(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error) {
+			return sampleUser, nil
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.UpdateUserRequest{FirstName: "สมหญิง"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1", body))
+	assertStatusUser(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateProfile_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		updateProfileFn: func(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error) {
+			return nil, errors.New("update failed")
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.UpdateUserRequest{FirstName: "สมหญิง"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+// --- ChangePassword ---
+
+func TestChangePassword_MissingUserID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, nil)
+	body := jsonBodyUser(t, models.ChangePasswordRequest{OldPassword: "old", NewPassword: "newpass123"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", body))
+	assertStatusUser(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestChangePassword_InvalidJSON(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", bytes.NewBufferString("{bad}")))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestChangePassword_ValidationError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	// new_password น้อยกว่า 8 ตัวอักษร
+	body := jsonBodyUser(t, map[string]any{"old_password": "old", "new_password": "short"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestChangePassword_WrongPassword(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		changePasswordFn: func(userID uint, input models.ChangePasswordRequest) error {
+			return errors.New("old password is incorrect")
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.ChangePasswordRequest{OldPassword: "wrong", NewPassword: "newpass123"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestChangePassword_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		changePasswordFn: func(userID uint, input models.ChangePasswordRequest) error { return nil },
+	}, &testUID)
+	body := jsonBodyUser(t, models.ChangePasswordRequest{OldPassword: "oldpass", NewPassword: "newpass123"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", body))
+	assertStatusUser(t, http.StatusOK, w.Code)
+}
+
+func TestChangePassword_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		changePasswordFn: func(userID uint, input models.ChangePasswordRequest) error {
+			return errors.New("hash failed")
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.ChangePasswordRequest{OldPassword: "oldpass", NewPassword: "newpass123"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/change-password", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+// --- DeleteUser ---
+
+func TestDeleteUser_MissingUserID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestDeleteUser_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		deleteUserFn: func(userID uint) error { return nil },
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusNoContent, w.Code)
+}
+
+func TestDeleteUser_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		deleteUserFn: func(userID uint) error { return errors.New("delete failed") },
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}

--- a/backend/controller/waterlog/waterlog_test.go
+++ b/backend/controller/waterlog/waterlog_test.go
@@ -1,0 +1,357 @@
+package waterlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/models"
+	"github.com/watermeter/suth/config/utils"
+)
+
+type mockWaterService struct {
+	getAllFn            func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error)
+	getByIDFn          func(id uint) (*models.WaterMeterValueResponse, error)
+	getLatestFn        func() ([]models.WaterMeterValueResponse, error)
+	getPendingFn       func() ([]models.WaterMeterValueResponse, error)
+	getStatusesFn      func() ([]models.StatusValueResponse, error)
+	createFn           func(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error)
+	updateFn           func(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error)
+	deleteFn           func(id uint) error
+}
+
+func (m *mockWaterService) GetAll(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+	return m.getAllFn(deviceID, statusID)
+}
+func (m *mockWaterService) GetByID(id uint) (*models.WaterMeterValueResponse, error) {
+	return m.getByIDFn(id)
+}
+func (m *mockWaterService) GetLatestPerDevice() ([]models.WaterMeterValueResponse, error) {
+	return m.getLatestFn()
+}
+func (m *mockWaterService) GetPending() ([]models.WaterMeterValueResponse, error) {
+	return m.getPendingFn()
+}
+func (m *mockWaterService) GetStatuses() ([]models.StatusValueResponse, error) {
+	return m.getStatusesFn()
+}
+func (m *mockWaterService) Create(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error) {
+	return m.createFn(input, userID)
+}
+func (m *mockWaterService) Update(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error) {
+	return m.updateFn(id, input)
+}
+func (m *mockWaterService) Delete(id uint) error {
+	return m.deleteFn(id)
+}
+
+// withUser injects a user ID into every request (simulates JWT middleware)
+func setupRouter(svc *mockWaterService, userID *uint) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	if userID != nil {
+		uid := *userID
+		r.Use(func(c *gin.Context) {
+			c.Set(utils.ContextUserIDKey, uid)
+			c.Next()
+		})
+	}
+	NewWaterLogHandler(r.Group("/api/v1"), svc)
+	return r
+}
+
+func assertStatus(t *testing.T, want, got int) {
+	t.Helper()
+	if want != got {
+		t.Errorf("status: want %d, got %d", want, got)
+	}
+}
+
+func jsonBody(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, _ := json.Marshal(v)
+	return bytes.NewBuffer(b)
+}
+
+func jsonReq(t *testing.T, method, url string, body *bytes.Buffer) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, url, body)
+	} else {
+		req = httptest.NewRequest(method, url, nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var uid = uint(1)
+var sampleValue = models.WaterMeterValueResponse{ID: 1, MeterValue: 100, DeviceID: 1}
+
+// --- GetAll ---
+
+func TestGetAll_NoParams(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+			if deviceID != nil || statusID != nil {
+				t.Error("expected nil params")
+			}
+			return []models.WaterMeterValueResponse{sampleValue}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAll_WithQueryParams(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+			if deviceID == nil || *deviceID != 2 {
+				t.Errorf("expected deviceID=2, got %v", deviceID)
+			}
+			if statusID == nil || *statusID != 3 {
+				t.Errorf("expected statusID=3, got %v", statusID)
+			}
+			return nil, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values?device_id=2&status_id=3", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetAll_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+			return nil, errors.New("db error")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetLatest ---
+
+func TestGetLatest_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getLatestFn: func() ([]models.WaterMeterValueResponse, error) {
+			return []models.WaterMeterValueResponse{sampleValue}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/latest", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetLatest_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getLatestFn: func() ([]models.WaterMeterValueResponse, error) {
+			return nil, errors.New("db error")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/latest", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetPending ---
+
+func TestGetPending_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getPendingFn: func() ([]models.WaterMeterValueResponse, error) {
+			return []models.WaterMeterValueResponse{sampleValue}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/pending", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetPending_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getPendingFn: func() ([]models.WaterMeterValueResponse, error) {
+			return nil, errors.New("db error")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/pending", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetStatuses ---
+
+func TestGetStatuses_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getStatusesFn: func() ([]models.StatusValueResponse, error) {
+			return []models.StatusValueResponse{{ID: 1, StatusValue: "รอ"}}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/statuses", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetStatuses_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getStatusesFn: func() ([]models.StatusValueResponse, error) {
+			return nil, errors.New("db error")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/statuses", nil))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetByID ---
+
+func TestGetByID_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getByIDFn: func(id uint) (*models.WaterMeterValueResponse, error) {
+			return &sampleValue, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/1", nil))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		getByIDFn: func(id uint) (*models.WaterMeterValueResponse, error) {
+			return nil, errors.New("not found")
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/water-values/99", nil))
+	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create ---
+
+func TestCreate_MissingUserID(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, nil) // no userID middleware
+	body := jsonBody(t, models.WaterMeterValueRequest{MeterValue: 100, DeviceID: 1})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/water-values", body))
+	assertStatus(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCreate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, &uid)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/water-values", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_ValidationError(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, &uid)
+	// meter_value=0 (zero → fails required) and device_id missing
+	body := jsonBody(t, map[string]any{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/water-values", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreate_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		createFn: func(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error) {
+			return &sampleValue, nil
+		},
+	}, &uid)
+	body := jsonBody(t, models.WaterMeterValueRequest{MeterValue: 100, DeviceID: 1})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/water-values", body))
+	assertStatus(t, http.StatusCreated, w.Code)
+}
+
+func TestCreate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		createFn: func(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error) {
+			return nil, errors.New("insert failed")
+		},
+	}, &uid)
+	body := jsonBody(t, models.WaterMeterValueRequest{MeterValue: 100, DeviceID: 1})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPost, "/api/v1/water-values", body))
+	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Update ---
+
+func TestUpdate_InvalidID(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/water-values/xyz", bytes.NewBufferString("{}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_InvalidJSON(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/water-values/1", bytes.NewBufferString("{bad}")))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		updateFn: func(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error) {
+			return &sampleValue, nil
+		},
+	}, nil)
+	body := jsonBody(t, models.UpdateWaterMeterValueRequest{StatusID: 2})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/water-values/1", body))
+	assertStatus(t, http.StatusOK, w.Code)
+}
+
+func TestUpdate_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		updateFn: func(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error) {
+			return nil, errors.New("update failed")
+		},
+	}, nil)
+	body := jsonBody(t, models.UpdateWaterMeterValueRequest{StatusID: 2})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReq(t, http.MethodPut, "/api/v1/water-values/1", body))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Delete ---
+
+func TestDelete_Success(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		deleteFn: func(id uint) error { return nil },
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/water-values/1", nil))
+	assertStatus(t, http.StatusNoContent, w.Code)
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	r := setupRouter(&mockWaterService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/water-values/abc", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDelete_ServiceError(t *testing.T) {
+	r := setupRouter(&mockWaterService{
+		deleteFn: func(id uint) error { return errors.New("delete failed") },
+	}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/water-values/1", nil))
+	assertStatus(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
- controller: meter (100%), notification (100%), users/auth (100%), device (97.4%), waterlog (97.8%), maintainlog (96.9%)
- config/utils: password (100%), jwt (100%), response (100%)
- controller/upload_image: sanitizeFilename, uintPtr (pure functions only)
- mock services via function-field structs — no DB or external deps required