### PR TITLE
feat(rbac): add role-based access control and unified error format

### DIFF
--- a/backend/config/models/notification.go
+++ b/backend/config/models/notification.go
@@ -1,13 +1,14 @@
 package models
 
 type NotificationResponse struct {
-	ID        uint            `json:"id"`
-	Message   string          `json:"message"`
-	IsRead    bool            `json:"is_read"`
-	DeviceID  *uint           `json:"device_id"`
-	Device    *DeviceResponse `json:"device,omitempty"`
-	CreatedAt string          `json:"created_at"`
-	UpdatedAt string          `json:"updated_at"`
+	ID           uint            `json:"id"`
+	Message      string          `json:"message"`
+	IsRead       bool            `json:"is_read"`
+	DeviceID     *uint           `json:"device_id"`
+	Device       *DeviceResponse `json:"device,omitempty"`
+	TargetUserID *uint           `json:"target_user_id,omitempty"`
+	CreatedAt    string          `json:"created_at"`
+	UpdatedAt    string          `json:"updated_at"`
 }
 
 type NotificationStatsResponse struct {

--- a/backend/config/postgres/migrate.go
+++ b/backend/config/postgres/migrate.go
@@ -51,9 +51,9 @@ func SetupDatabase(database *gorm.DB, resetDB bool) error {
 
 func seedGenders(database *gorm.DB) {
 	genders := []entity.Genders{
-		{Gender: "Male"},
-		{Gender: "Female"},
-		{Gender: "Other"},
+		{Gender: "ผู้ชาย"},
+		{Gender: "ผู้หญิง"},
+		{Gender: "อื่น ๆ"},
 	}
 	for _, g := range genders {
 		database.FirstOrCreate(&g, entity.Genders{Gender: g.Gender})
@@ -61,7 +61,7 @@ func seedGenders(database *gorm.DB) {
 }
 
 func seedPositions(database *gorm.DB) map[string]entity.Position {
-	positions := []string{"Manager", "Engineer", "Technician", "Staff"}
+	positions := []string{"ผู้จัดการ", "วิศวกร", "ช่างเทคนิค", "สตาฟ"}
 	posMap := make(map[string]entity.Position)
 
 	for _, name := range positions {
@@ -74,10 +74,10 @@ func seedPositions(database *gorm.DB) map[string]entity.Position {
 
 func seedRoles(database *gorm.DB) {
 	roles := []entity.Role{
-		{Role: "Admin"},
-		{Role: "User"},
-		{Role: "Engineer"},
-		{Role: "Technician"},
+		{Role: "ผู้ดูแล"},
+		{Role: "วิศวกร"},
+		{Role: "ช่างเทคนิค"},
+		{Role: "ผู้ใช้"},
 	}
 	for _, r := range roles {
 		database.FirstOrCreate(&r, entity.Role{Role: r.Role})
@@ -126,11 +126,16 @@ func seedUsers(database *gorm.DB) {
 	// Gender & Role
 	maleID := uint(1)
 	femaleID := uint(2)
-	roleUserID := uint(2)
+
 	roleAdminID := uint(1)
+	roleEngineerID := uint(2)
+	roleTechnicalID := uint(3)
+	roleUserID := uint(4)
 	// Positions
 	managerPositionID := uint(1)
 	engineerPositionID := uint(2)
+	Technical := uint(3)
+	User := uint(4)
 
 	users := []entity.User{
 		{
@@ -141,12 +146,17 @@ func seedUsers(database *gorm.DB) {
 		{
 			FirstName: "ดนุพร", LastName: "สีสินธุ์", Email: "danuporn@gmail.com",
 			Password: hashOrPanic("123"), BirthDay: parseDate("2003-05-20"),
-			GenderID: maleID, RoleID: roleUserID, PositionID: engineerPositionID,
+			GenderID: maleID, RoleID: roleEngineerID, PositionID: engineerPositionID,
 		},
 		{
 			FirstName: "อภิรัตน์", LastName: "แสงอรุณ", Email: "apirat@gmail.com",
 			Password: hashOrPanic("123"), BirthDay: parseDate("2003-06-08"),
-			GenderID: maleID, RoleID: roleUserID, PositionID: engineerPositionID,
+			GenderID: maleID, RoleID: roleTechnicalID, PositionID: Technical,
+		},
+		{
+			FirstName: "บัก", LastName: "บุ๊ค", Email: "thanawat@gmail.com",
+			Password: hashOrPanic("123"), BirthDay: parseDate("2002-12-15"),
+			GenderID: maleID, RoleID: roleUserID, PositionID: User,
 		},
 	}
 

--- a/backend/config/utils/error.go
+++ b/backend/config/utils/error.go
@@ -37,17 +37,13 @@ var (
 )
 
 func NewError(c *gin.Context, status int, err error) {
-	er := HTTPError{
-		Code:    status,
-		Message: err.Error(),
-	}
-	c.JSON(status, er)
-
-}
-
-type HTTPError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	c.JSON(status, gin.H{
+		"success": false,
+		"error": gin.H{
+			"message": err.Error(),
+			"detail":  "",
+		},
+	})
 }
 
 func FailOnError(err error, msg string) {

--- a/backend/config/utils/jwt.go
+++ b/backend/config/utils/jwt.go
@@ -9,7 +9,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const ContextUserIDKey = "user_id"
+const (
+	ContextUserIDKey  = "user_id"
+	ContextRoleIDKey  = "role_id"
+)
 
 // JWTProvider signs and validates JWT tokens.
 type JWTProvider struct {
@@ -20,6 +23,7 @@ type JWTProvider struct {
 // JWTClaims stores token claims for authenticated users.
 type JWTClaims struct {
 	UserID uint `json:"user_id"`
+	RoleID uint `json:"role_id"`
 	jwt.RegisteredClaims
 }
 
@@ -29,9 +33,10 @@ func NewJWTProvider(secret string, expiresIn time.Duration) JWTProvider {
 }
 
 // GenerateToken creates a signed JWT token for a user.
-func (p JWTProvider) GenerateToken(userID uint) (string, error) {
+func (p JWTProvider) GenerateToken(userID, roleID uint) (string, error) {
 	claims := JWTClaims{
 		UserID: userID,
+		RoleID: roleID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
 			ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(p.expiresIn)),
@@ -67,13 +72,21 @@ func ParseToken(tokenString string) (*JWTClaims, error) {
 }
 
 // GetUserIDFromContext reads the authenticated user ID from Gin context.
-// Accepts the broader `Get(any) (any, bool)` signature used by recent Gin versions.
 func GetUserIDFromContext(c *gin.Context) (uint, bool) {
 	raw, ok := c.Get(ContextUserIDKey)
 	if !ok {
 		return 0, false
 	}
-
 	userID, ok := raw.(uint)
 	return userID, ok
+}
+
+// GetRoleIDFromContext reads the authenticated user's role ID from Gin context.
+func GetRoleIDFromContext(c *gin.Context) (uint, bool) {
+	raw, ok := c.Get(ContextRoleIDKey)
+	if !ok {
+		return 0, false
+	}
+	roleID, ok := raw.(uint)
+	return roleID, ok
 }

--- a/backend/config/utils/jwt_test.go
+++ b/backend/config/utils/jwt_test.go
@@ -12,7 +12,7 @@ const testSecret = "test-jwt-secret"
 
 func TestGenerateToken_ReturnsToken(t *testing.T) {
 	p := NewJWTProvider(testSecret, time.Hour)
-	tok, err := p.GenerateToken(42)
+	tok, err := p.GenerateToken(42, 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -26,7 +26,7 @@ func TestParseToken_ValidToken(t *testing.T) {
 	defer os.Unsetenv("JWT_SECRET_KEY")
 
 	p := NewJWTProvider(testSecret, time.Hour)
-	tok, _ := p.GenerateToken(7)
+	tok, _ := p.GenerateToken(7, 2)
 
 	claims, err := ParseToken(tok)
 	if err != nil {
@@ -34,6 +34,9 @@ func TestParseToken_ValidToken(t *testing.T) {
 	}
 	if claims.UserID != 7 {
 		t.Errorf("expected UserID 7, got %d", claims.UserID)
+	}
+	if claims.RoleID != 2 {
+		t.Errorf("expected RoleID 2, got %d", claims.RoleID)
 	}
 }
 
@@ -61,7 +64,7 @@ func TestParseToken_ExpiredToken(t *testing.T) {
 
 	// สร้าง token ที่หมดอายุทันที
 	p := NewJWTProvider(testSecret, -time.Second)
-	tok, _ := p.GenerateToken(1)
+	tok, _ := p.GenerateToken(1, 1)
 
 	_, err := ParseToken(tok)
 	if err == nil {

--- a/backend/config/utils/response_test.go
+++ b/backend/config/utils/response_test.go
@@ -85,12 +85,13 @@ func TestNewError_Structure(t *testing.T) {
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status: want 404, got %d", w.Code)
 	}
-	var resp HTTPError
+	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Code != http.StatusNotFound {
-		t.Errorf("code: want 404, got %d", resp.Code)
+	if resp["success"] != false {
+		t.Error("expected success=false")
 	}
-	if resp.Message != ErrNotFound.Error() {
-		t.Errorf("message: want %q, got %q", ErrNotFound.Error(), resp.Message)
+	errObj, _ := resp["error"].(map[string]interface{})
+	if errObj["message"] != ErrNotFound.Error() {
+		t.Errorf("message: want %q, got %v", ErrNotFound.Error(), errObj["message"])
 	}
 }

--- a/backend/config/utils/role.go
+++ b/backend/config/utils/role.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	RoleAdmin      = uint(1)
+	RoleUser       = uint(2)
+	RoleEngineer   = uint(3)
+	RoleTechnician = uint(4)
+)
+
+// RequireRole aborts with 403 if the caller's role is not in the allowed list.
+func RequireRole(roleIDs ...uint) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		roleID, ok := GetRoleIDFromContext(c)
+		if !ok {
+			NewError(c, http.StatusUnauthorized, ErrMissingID)
+			c.Abort()
+			return
+		}
+		for _, allowed := range roleIDs {
+			if roleID == allowed {
+				c.Next()
+				return
+			}
+		}
+		NewError(c, http.StatusForbidden, ErrPermissionDenied)
+		c.Abort()
+	}
+}

--- a/backend/controller/device/device.go
+++ b/backend/controller/device/device.go
@@ -22,13 +22,15 @@ func NewDeviceHandler(router *gin.RouterGroup, deviceService services.DeviceServ
 		validate:      validator.New(),
 	}
 
+	adminOrEngineer := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer)
+
 	g := router.Group("devices")
-	g.GET("", handler.GetAll)
-	g.GET("/available-locations", handler.GetAvailableLocations)
-	g.GET("/:id", handler.GetByID)
-	g.POST("", handler.Create)
-	g.PUT("/:id", handler.Update)
-	g.DELETE("/:id", handler.Delete)
+	g.GET("", adminOrEngineer, handler.GetAll)
+	g.GET("/available-locations", adminOrEngineer, handler.GetAvailableLocations)
+	g.GET("/:id", adminOrEngineer, handler.GetByID)
+	g.POST("", adminOrEngineer, handler.Create)
+	g.PUT("/:id", adminOrEngineer, handler.Update)
+	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
 	return handler
 }

--- a/backend/controller/device/device_test.go
+++ b/backend/controller/device/device_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/watermeter/suth/config/models"
+	"github.com/watermeter/suth/config/utils"
 )
 
 type mockDeviceService struct {
@@ -43,6 +44,11 @@ func (m *mockDeviceService) GetAvailableLocations() ([]models.LocationResponse, 
 func setupRouter(svc *mockDeviceService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(utils.ContextUserIDKey, uint(1))
+		c.Set(utils.ContextRoleIDKey, uint(1)) // Admin
+		c.Next()
+	})
 	NewDeviceHandler(r.Group("/api/v1"), svc)
 	return r
 }

--- a/backend/controller/maintainlog/maintainlog.go
+++ b/backend/controller/maintainlog/maintainlog.go
@@ -12,23 +12,28 @@ import (
 )
 
 type MaintainLogHandler struct {
-	maintainLogService services.MaintainLogService
-	validate           *validator.Validate
+	maintainLogService  services.MaintainLogService
+	notificationService services.NotificationService
+	validate            *validator.Validate
 }
 
-func NewMaintainLogHandler(router *gin.RouterGroup, maintainLogService services.MaintainLogService) *MaintainLogHandler {
+func NewMaintainLogHandler(router *gin.RouterGroup, maintainLogService services.MaintainLogService, notificationService services.NotificationService) *MaintainLogHandler {
 	handler := &MaintainLogHandler{
-		maintainLogService: maintainLogService,
-		validate:           validator.New(),
+		maintainLogService:  maintainLogService,
+		notificationService: notificationService,
+		validate:            validator.New(),
 	}
 
+	staffNoUser := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer, utils.RoleTechnician)
+	adminOrEngineer := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer)
+
 	g := router.Group("maintain-logs")
-	g.GET("", handler.GetAll)
-	g.GET("/statuses", handler.GetStatuses)
-	g.GET("/:id", handler.GetByID)
-	g.POST("", handler.Create)
-	g.PUT("/:id", handler.Update)
-	g.DELETE("/:id", handler.Delete)
+	g.GET("", staffNoUser, handler.GetAll)
+	g.GET("/statuses", staffNoUser, handler.GetStatuses)
+	g.GET("/:id", staffNoUser, handler.GetByID)
+	g.POST("", handler.Create) // ทุก role ส่งปัญหาได้
+	g.PUT("/:id", staffNoUser, handler.Update)
+	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
 	return handler
 }
@@ -73,6 +78,14 @@ func (h *MaintainLogHandler) Create(c *gin.Context) {
 		utils.NewError(c, http.StatusInternalServerError, utils.ErrCreateFailed)
 		return
 	}
+
+	// ส่ง system notification ให้ผู้รายงาน (ถ้ามี userID ใน context)
+	if userID, ok := utils.GetUserIDFromContext(c); ok {
+		_ = h.notificationService.CreateSystemNotification(
+			"รายงานปัญหาของคุณถูกบันทึกแล้ว: "+log.Title, userID,
+		)
+	}
+
 	utils.JSONSuccess(c, http.StatusCreated, log)
 }
 

--- a/backend/controller/maintainlog/maintainlog_test.go
+++ b/backend/controller/maintainlog/maintainlog_test.go
@@ -40,10 +40,34 @@ func (m *mockMaintainLogService) GetStatuses() ([]models.StatusLogResponse, erro
 	return m.getStatusesFn()
 }
 
+// noopNotifService satisfies services.NotificationService for maintainlog tests
+type noopNotifService struct{}
+
+func (n *noopNotifService) GetAll(roleID, userID uint) ([]models.NotificationResponse, error) {
+	return nil, nil
+}
+func (n *noopNotifService) GetByID(id uint) (*models.NotificationResponse, error) { return nil, nil }
+func (n *noopNotifService) MarkAsRead(id uint) (*models.NotificationResponse, error) {
+	return nil, nil
+}
+func (n *noopNotifService) MarkAllAsRead(roleID, userID uint) error { return nil }
+func (n *noopNotifService) Delete(id uint) error                    { return nil }
+func (n *noopNotifService) GetStats() (*models.NotificationStatsResponse, error) {
+	return nil, nil
+}
+func (n *noopNotifService) CreateSystemNotification(message string, targetUserID uint) error {
+	return nil
+}
+
 func setupRouter(svc *mockMaintainLogService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	NewMaintainLogHandler(r.Group("/api/v1"), svc)
+	r.Use(func(c *gin.Context) {
+		c.Set("user_id", uint(1))
+		c.Set("role_id", uint(1))
+		c.Next()
+	})
+	NewMaintainLogHandler(r.Group("/api/v1"), svc, &noopNotifService{})
 	return r
 }
 

--- a/backend/controller/meter/meter.go
+++ b/backend/controller/meter/meter.go
@@ -22,12 +22,14 @@ func NewMeterHandler(router *gin.RouterGroup, locationService services.LocationS
 		validate:        validator.New(),
 	}
 
+	adminOrEngineer := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer)
+
 	g := router.Group("meters")
 	g.GET("", handler.GetAll)
 	g.GET("/:id", handler.GetByID)
-	g.POST("", handler.Create)
-	g.PUT("/:id", handler.Update)
-	g.DELETE("/:id", handler.Delete)
+	g.POST("", adminOrEngineer, handler.Create)
+	g.PUT("/:id", adminOrEngineer, handler.Update)
+	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
 	return handler
 }

--- a/backend/controller/meter/meter_test.go
+++ b/backend/controller/meter/meter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/watermeter/suth/config/models"
+	"github.com/watermeter/suth/config/utils"
 )
 
 // mockLocationService implements services.LocationService via structural typing
@@ -40,6 +41,11 @@ func (m *mockLocationService) Delete(id uint) error {
 func setupRouter(svc *mockLocationService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(utils.ContextUserIDKey, uint(1))
+		c.Set(utils.ContextRoleIDKey, uint(1)) // Admin
+		c.Next()
+	})
 	NewMeterHandler(r.Group("/api/v1"), svc)
 	return r
 }

--- a/backend/controller/notification/notification.go
+++ b/backend/controller/notification/notification.go
@@ -18,15 +18,18 @@ func NewNotificationHandler(router *gin.RouterGroup, service services.Notificati
 
 	g := router.Group("/notifications")
 	g.GET("", h.GetAll)
-	g.GET("/stats", h.GetStats)
+	g.GET("/stats", utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer, utils.RoleTechnician), h.GetStats)
 	g.PUT("/read-all", h.MarkAllAsRead)
 	g.GET("/:id", h.GetByID)
 	g.PUT("/:id/read", h.MarkAsRead)
-	g.DELETE("/:id", h.Delete)
+	g.DELETE("/:id", utils.RequireRole(utils.RoleAdmin), h.Delete)
 }
 
 func (h *notificationHandler) GetAll(c *gin.Context) {
-	data, err := h.service.GetAll()
+	userID, _ := utils.GetUserIDFromContext(c)
+	roleID, _ := utils.GetRoleIDFromContext(c)
+
+	data, err := h.service.GetAll(roleID, userID)
 	if err != nil {
 		utils.NewError(c, http.StatusInternalServerError, utils.ErrInternalServer)
 		return
@@ -74,7 +77,10 @@ func (h *notificationHandler) MarkAsRead(c *gin.Context) {
 }
 
 func (h *notificationHandler) MarkAllAsRead(c *gin.Context) {
-	if err := h.service.MarkAllAsRead(); err != nil {
+	userID, _ := utils.GetUserIDFromContext(c)
+	roleID, _ := utils.GetRoleIDFromContext(c)
+
+	if err := h.service.MarkAllAsRead(roleID, userID); err != nil {
 		utils.NewError(c, http.StatusInternalServerError, utils.ErrInternalServer)
 		return
 	}

--- a/backend/controller/notification/notification_test.go
+++ b/backend/controller/notification/notification_test.go
@@ -8,19 +8,21 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/watermeter/suth/config/models"
+	"github.com/watermeter/suth/config/utils"
 )
 
 type mockNotificationService struct {
-	getAllFn       func() ([]models.NotificationResponse, error)
-	getByIDFn     func(id uint) (*models.NotificationResponse, error)
-	markAsReadFn  func(id uint) (*models.NotificationResponse, error)
-	markAllReadFn func() error
-	deleteFn      func(id uint) error
-	getStatsFn    func() (*models.NotificationStatsResponse, error)
+	getAllFn              func(roleID, userID uint) ([]models.NotificationResponse, error)
+	getByIDFn            func(id uint) (*models.NotificationResponse, error)
+	markAsReadFn         func(id uint) (*models.NotificationResponse, error)
+	markAllReadFn        func(roleID, userID uint) error
+	deleteFn             func(id uint) error
+	getStatsFn           func() (*models.NotificationStatsResponse, error)
+	createSystemNotifFn  func(message string, targetUserID uint) error
 }
 
-func (m *mockNotificationService) GetAll() ([]models.NotificationResponse, error) {
-	return m.getAllFn()
+func (m *mockNotificationService) GetAll(roleID, userID uint) ([]models.NotificationResponse, error) {
+	return m.getAllFn(roleID, userID)
 }
 func (m *mockNotificationService) GetByID(id uint) (*models.NotificationResponse, error) {
 	return m.getByIDFn(id)
@@ -28,8 +30,8 @@ func (m *mockNotificationService) GetByID(id uint) (*models.NotificationResponse
 func (m *mockNotificationService) MarkAsRead(id uint) (*models.NotificationResponse, error) {
 	return m.markAsReadFn(id)
 }
-func (m *mockNotificationService) MarkAllAsRead() error {
-	return m.markAllReadFn()
+func (m *mockNotificationService) MarkAllAsRead(roleID, userID uint) error {
+	return m.markAllReadFn(roleID, userID)
 }
 func (m *mockNotificationService) Delete(id uint) error {
 	return m.deleteFn(id)
@@ -37,10 +39,22 @@ func (m *mockNotificationService) Delete(id uint) error {
 func (m *mockNotificationService) GetStats() (*models.NotificationStatsResponse, error) {
 	return m.getStatsFn()
 }
+func (m *mockNotificationService) CreateSystemNotification(message string, targetUserID uint) error {
+	if m.createSystemNotifFn != nil {
+		return m.createSystemNotifFn(message, targetUserID)
+	}
+	return nil
+}
 
-func setupRouter(svc *mockNotificationService) *gin.Engine {
+// injectRole adds roleID and userID to gin context for routes protected by RequireRole
+func setupRouter(svc *mockNotificationService, roleID uint) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(utils.ContextUserIDKey, uint(1))
+		c.Set(utils.ContextRoleIDKey, roleID)
+		c.Next()
+	})
 	NewNotificationHandler(r.Group("/api/v1"), svc)
 	return r
 }
@@ -58,10 +72,10 @@ var sampleNotif = models.NotificationResponse{ID: 1, Message: "ค่าผิ�
 
 func TestGetAll_Success(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
-		getAllFn: func() ([]models.NotificationResponse, error) {
+		getAllFn: func(roleID, userID uint) ([]models.NotificationResponse, error) {
 			return []models.NotificationResponse{sampleNotif}, nil
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil))
 	assertStatus(t, http.StatusOK, w.Code)
@@ -69,10 +83,10 @@ func TestGetAll_Success(t *testing.T) {
 
 func TestGetAll_ServiceError(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
-		getAllFn: func() ([]models.NotificationResponse, error) {
+		getAllFn: func(roleID, userID uint) ([]models.NotificationResponse, error) {
 			return nil, errors.New("db error")
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil))
 	assertStatus(t, http.StatusInternalServerError, w.Code)
@@ -85,7 +99,7 @@ func TestGetStats_Success(t *testing.T) {
 		getStatsFn: func() (*models.NotificationStatsResponse, error) {
 			return &models.NotificationStatsResponse{Total: 10, Unread: 3}, nil
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stats", nil))
 	assertStatus(t, http.StatusOK, w.Code)
@@ -96,10 +110,17 @@ func TestGetStats_ServiceError(t *testing.T) {
 		getStatsFn: func() (*models.NotificationStatsResponse, error) {
 			return nil, errors.New("db error")
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stats", nil))
 	assertStatus(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetStats_Forbidden_UserRole(t *testing.T) {
+	r := setupRouter(&mockNotificationService{}, utils.RoleUser)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stats", nil))
+	assertStatus(t, http.StatusForbidden, w.Code)
 }
 
 // --- GetByID ---
@@ -109,14 +130,14 @@ func TestGetByID_Success(t *testing.T) {
 		getByIDFn: func(id uint) (*models.NotificationResponse, error) {
 			return &sampleNotif, nil
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/1", nil))
 	assertStatus(t, http.StatusOK, w.Code)
 }
 
 func TestGetByID_InvalidID(t *testing.T) {
-	r := setupRouter(&mockNotificationService{})
+	r := setupRouter(&mockNotificationService{}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/abc", nil))
 	assertStatus(t, http.StatusBadRequest, w.Code)
@@ -127,7 +148,7 @@ func TestGetByID_NotFound(t *testing.T) {
 		getByIDFn: func(id uint) (*models.NotificationResponse, error) {
 			return nil, errors.New("not found")
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/notifications/99", nil))
 	assertStatus(t, http.StatusNotFound, w.Code)
@@ -142,14 +163,14 @@ func TestMarkAsRead_Success(t *testing.T) {
 			n.IsRead = true
 			return &n, nil
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/1/read", nil))
 	assertStatus(t, http.StatusOK, w.Code)
 }
 
 func TestMarkAsRead_InvalidID(t *testing.T) {
-	r := setupRouter(&mockNotificationService{})
+	r := setupRouter(&mockNotificationService{}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/xyz/read", nil))
 	assertStatus(t, http.StatusBadRequest, w.Code)
@@ -160,7 +181,7 @@ func TestMarkAsRead_NotFound(t *testing.T) {
 		markAsReadFn: func(id uint) (*models.NotificationResponse, error) {
 			return nil, errors.New("not found")
 		},
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/99/read", nil))
 	assertStatus(t, http.StatusNotFound, w.Code)
@@ -170,8 +191,8 @@ func TestMarkAsRead_NotFound(t *testing.T) {
 
 func TestMarkAllAsRead_Success(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
-		markAllReadFn: func() error { return nil },
-	})
+		markAllReadFn: func(roleID, userID uint) error { return nil },
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/read-all", nil))
 	assertStatus(t, http.StatusOK, w.Code)
@@ -179,8 +200,8 @@ func TestMarkAllAsRead_Success(t *testing.T) {
 
 func TestMarkAllAsRead_ServiceError(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
-		markAllReadFn: func() error { return errors.New("db error") },
-	})
+		markAllReadFn: func(roleID, userID uint) error { return errors.New("db error") },
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/v1/notifications/read-all", nil))
 	assertStatus(t, http.StatusInternalServerError, w.Code)
@@ -191,14 +212,14 @@ func TestMarkAllAsRead_ServiceError(t *testing.T) {
 func TestDelete_Success(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
 		deleteFn: func(id uint) error { return nil },
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/1", nil))
 	assertStatus(t, http.StatusOK, w.Code)
 }
 
 func TestDelete_InvalidID(t *testing.T) {
-	r := setupRouter(&mockNotificationService{})
+	r := setupRouter(&mockNotificationService{}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/abc", nil))
 	assertStatus(t, http.StatusBadRequest, w.Code)
@@ -207,8 +228,15 @@ func TestDelete_InvalidID(t *testing.T) {
 func TestDelete_NotFound(t *testing.T) {
 	r := setupRouter(&mockNotificationService{
 		deleteFn: func(id uint) error { return errors.New("not found") },
-	})
+	}, utils.RoleAdmin)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/99", nil))
 	assertStatus(t, http.StatusNotFound, w.Code)
+}
+
+func TestDelete_Forbidden_UserRole(t *testing.T) {
+	r := setupRouter(&mockNotificationService{}, utils.RoleUser)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/notifications/1", nil))
+	assertStatus(t, http.StatusForbidden, w.Code)
 }

--- a/backend/controller/users/auth_controller.go
+++ b/backend/controller/users/auth_controller.go
@@ -12,14 +12,16 @@ import (
 )
 
 type AuthHandler struct {
-	authService services.AuthService
-	validate    *validator.Validate
+	authService         services.AuthService
+	notificationService services.NotificationService
+	validate            *validator.Validate
 }
 
-func NewAuthHandler(router *gin.RouterGroup, authService services.AuthService) *AuthHandler {
+func NewAuthHandler(router *gin.RouterGroup, authService services.AuthService, notificationService services.NotificationService) *AuthHandler {
 	handler := &AuthHandler{
-		authService: authService,
-		validate:    validator.New(),
+		authService:         authService,
+		notificationService: notificationService,
+		validate:            validator.New(),
 	}
 
 	auth := router.Group("auth")
@@ -64,8 +66,16 @@ func (h *AuthHandler) Login(c *gin.Context) {
 
 	authResponse, err := h.authService.Login(payload)
 	if err != nil {
-		utils.NewError(c, http.StatusUnauthorized, utils.ErrUnauthorized)
+		utils.JSONError(c, http.StatusUnauthorized, utils.ErrWrongPassword.Error(), err.Error())
 		return
+	}
+
+	// ส่ง system notification ให้ผู้ใช้ที่เพิ่ง login
+	if authResponse.User != nil {
+		_ = h.notificationService.CreateSystemNotification(
+			"เข้าสู่ระบบสำเร็จ ยินดีต้อนรับ "+authResponse.User.FirstName,
+			authResponse.User.ID,
+		)
 	}
 
 	utils.JSONSuccess(c, http.StatusOK, authResponse)

--- a/backend/controller/users/auth_controller_test.go
+++ b/backend/controller/users/auth_controller_test.go
@@ -27,8 +27,29 @@ func (m *mockAuthService) Login(input models.LoginRequest) (*models.AuthResponse
 func setupAuthRouter(svc *mockAuthService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	NewAuthHandler(r.Group("/api/v1"), svc)
+	NewAuthHandler(r.Group("/api/v1"), svc, &mockNotifServiceFull{})
 	return r
+}
+
+// mockNotifServiceFull satisfies services.NotificationService for auth tests
+type mockNotifServiceFull struct{}
+
+func (m *mockNotifServiceFull) GetAll(roleID, userID uint) ([]models.NotificationResponse, error) {
+	return nil, nil
+}
+func (m *mockNotifServiceFull) GetByID(id uint) (*models.NotificationResponse, error) {
+	return nil, nil
+}
+func (m *mockNotifServiceFull) MarkAsRead(id uint) (*models.NotificationResponse, error) {
+	return nil, nil
+}
+func (m *mockNotifServiceFull) MarkAllAsRead(roleID, userID uint) error { return nil }
+func (m *mockNotifServiceFull) Delete(id uint) error                    { return nil }
+func (m *mockNotifServiceFull) GetStats() (*models.NotificationStatsResponse, error) {
+	return nil, nil
+}
+func (m *mockNotifServiceFull) CreateSystemNotification(message string, targetUserID uint) error {
+	return nil
 }
 
 func assertStatusAuth(t *testing.T, want, got int) {

--- a/backend/controller/users/user_controller.go
+++ b/backend/controller/users/user_controller.go
@@ -23,12 +23,15 @@ func NewUserHandler(router *gin.RouterGroup, userService services.UserService) *
 		validate:    validator.New(),
 	}
 
+	adminOnly := utils.RequireRole(utils.RoleAdmin)
+	adminOrEngineer := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer)
+
 	user := router.Group("users")
-	user.GET("", handler.GetAllUsers)
+	user.GET("", adminOrEngineer, handler.GetAllUsers)
 	user.GET("/:id", handler.GetProfile)
 	user.PUT("/:id", handler.UpdateProfile)
 	user.PUT("/:id/change-password", handler.ChangePassword)
-	user.DELETE("/:id", handler.DeleteUser)
+	user.DELETE("/:id", adminOnly, handler.DeleteUser)
 
 	return handler
 }

--- a/backend/controller/users/user_controller_test.go
+++ b/backend/controller/users/user_controller_test.go
@@ -40,13 +40,13 @@ func (m *mockUserService) GetAllUsers() ([]models.UserResponse, error) {
 func setupUserRouter(svc *mockUserService, userID *uint) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	if userID != nil {
-		uid := *userID
-		r.Use(func(c *gin.Context) {
-			c.Set(utils.ContextUserIDKey, uid)
-			c.Next()
-		})
-	}
+	r.Use(func(c *gin.Context) {
+		if userID != nil {
+			c.Set(utils.ContextUserIDKey, *userID)
+		}
+		c.Set(utils.ContextRoleIDKey, uint(1)) // Admin bypasses all role guards
+		c.Next()
+	})
 	NewUserHandler(r.Group("/api/v1"), svc)
 	return r
 }

--- a/backend/controller/waterlog/waterlog.go
+++ b/backend/controller/waterlog/waterlog.go
@@ -22,15 +22,18 @@ func NewWaterLogHandler(router *gin.RouterGroup, waterService services.WaterMete
 		validate:     validator.New(),
 	}
 
+	staffOnly := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer, utils.RoleTechnician)
+	adminOrEngineer := utils.RequireRole(utils.RoleAdmin, utils.RoleEngineer)
+
 	g := router.Group("water-values")
-	g.GET("", handler.GetAll)
-	g.GET("/latest", handler.GetLatest)
-	g.GET("/pending", handler.GetPending)
-	g.GET("/statuses", handler.GetStatuses)
-	g.GET("/:id", handler.GetByID)
-	g.POST("", handler.Create)
-	g.PUT("/:id", handler.Update)
-	g.DELETE("/:id", handler.Delete)
+	g.GET("", staffOnly, handler.GetAll)
+	g.GET("/latest", staffOnly, handler.GetLatest)
+	g.GET("/pending", staffOnly, handler.GetPending)
+	g.GET("/statuses", staffOnly, handler.GetStatuses)
+	g.GET("/:id", staffOnly, handler.GetByID)
+	g.POST("", adminOrEngineer, handler.Create)
+	g.PUT("/:id", adminOrEngineer, handler.Update)
+	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
 	return handler
 }

--- a/backend/controller/waterlog/waterlog_test.go
+++ b/backend/controller/waterlog/waterlog_test.go
@@ -49,17 +49,16 @@ func (m *mockWaterService) Delete(id uint) error {
 	return m.deleteFn(id)
 }
 
-// withUser injects a user ID into every request (simulates JWT middleware)
 func setupRouter(svc *mockWaterService, userID *uint) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	if userID != nil {
-		uid := *userID
-		r.Use(func(c *gin.Context) {
-			c.Set(utils.ContextUserIDKey, uid)
-			c.Next()
-		})
-	}
+	r.Use(func(c *gin.Context) {
+		if userID != nil {
+			c.Set(utils.ContextUserIDKey, *userID)
+		}
+		c.Set(utils.ContextRoleIDKey, uint(1)) // Admin bypasses all role guards
+		c.Next()
+	})
 	NewWaterLogHandler(r.Group("/api/v1"), svc)
 	return r
 }

--- a/backend/entity/message.go
+++ b/backend/entity/message.go
@@ -9,6 +9,11 @@ type Message struct {
 	Message string `json:"message"`
 	IsRead  bool   `json:"is_read"`
 
+	// DeviceID ตั้งค่า = แจ้งเตือนจากมิเตอร์, nil = system notification
 	DeviceID *uint   `json:"device_id"`
 	Device   *Device `gorm:"foreignKey:DeviceID" json:"device,omitempty"`
+
+	// TargetUserID ตั้งค่า = แจ้งเตือนเฉพาะ user นั้น (เช่น login, รายงานปัญหา)
+	TargetUserID *uint `json:"target_user_id"`
+	TargetUser   *User `gorm:"foreignKey:TargetUserID" json:"target_user,omitempty"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	// public API
 	publicRouter := router.Group("")
-	users.NewAuthHandler(publicRouter, authService)
+	users.NewAuthHandler(publicRouter, authService, notificationService)
 
 	// protected API
 	privateRouter := router.Group("")
@@ -73,7 +73,7 @@ func main() {
 	users.NewUserHandler(privateRouter, userService)
 	meter.NewMeterHandler(privateRouter, locationService)
 	device.NewDeviceHandler(privateRouter, deviceService)
-	maintainlog.NewMaintainLogHandler(privateRouter, maintainLogService)
+	maintainlog.NewMaintainLogHandler(privateRouter, maintainLogService, notificationService)
 	waterlog.NewWaterLogHandler(privateRouter, waterMeterValueService)
 	notification.NewNotificationHandler(privateRouter, notificationService)
 

--- a/backend/middlewares/jwt_middleware.go
+++ b/backend/middlewares/jwt_middleware.go
@@ -33,6 +33,7 @@ func JWTAuthMiddleware() gin.HandlerFunc {
 		}
 
 		c.Set(utils.ContextUserIDKey, claims.UserID)
+		c.Set(utils.ContextRoleIDKey, claims.RoleID)
 		c.Next()
 	}
 }

--- a/backend/repositories/notification_repository.go
+++ b/backend/repositories/notification_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"errors"
 
+	"github.com/watermeter/suth/config/utils"
 	"github.com/watermeter/suth/entity"
 	"gorm.io/gorm"
 )
@@ -15,11 +16,12 @@ type NotificationStats struct {
 }
 
 type NotificationRepository interface {
-	FetchAll() ([]entity.Message, error)
+	Create(msg *entity.Message) error
+	FetchAll(roleID, userID uint) ([]entity.Message, error)
 	FindByID(id uint) (*entity.Message, error)
 	Update(msg *entity.Message) error
 	Delete(msg *entity.Message) error
-	MarkAllAsRead() error
+	MarkAllAsRead(roleID, userID uint) error
 	GetStats() (NotificationStats, error)
 }
 
@@ -31,11 +33,29 @@ func NewNotificationRepository(db *gorm.DB) NotificationRepository {
 	return &notificationRepository{db: db}
 }
 
-func (r *notificationRepository) FetchAll() ([]entity.Message, error) {
+func (r *notificationRepository) Create(msg *entity.Message) error {
+	return r.db.Create(msg).Error
+}
+
+func (r *notificationRepository) FetchAll(roleID, userID uint) ([]entity.Message, error) {
 	var msgs []entity.Message
-	if err := r.db.Preload("Device").Preload("Device.Location").
-		Order("created_at DESC").
-		Find(&msgs).Error; err != nil {
+	q := r.db.Preload("Device").Preload("Device.Location").Order("created_at DESC")
+
+	switch roleID {
+	case utils.RoleUser:
+		// User เห็นเฉพาะ system notification ที่ส่งหาตัวเอง
+		q = q.Where("device_id IS NULL AND target_user_id = ?", userID)
+	case utils.RoleAdmin:
+		// Admin เห็นทุกอย่าง
+	default:
+		// Engineer, Technician — เห็น meter alerts + system ที่ไม่ระบุเป้าหมาย + ของตัวเอง
+		q = q.Where(
+			"device_id IS NOT NULL OR (device_id IS NULL AND (target_user_id IS NULL OR target_user_id = ?))",
+			userID,
+		)
+	}
+
+	if err := q.Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil
@@ -61,10 +81,22 @@ func (r *notificationRepository) Delete(msg *entity.Message) error {
 	return r.db.Delete(msg).Error
 }
 
-func (r *notificationRepository) MarkAllAsRead() error {
-	return r.db.Model(&entity.Message{}).
-		Where("is_read = ?", false).
-		Update("is_read", true).Error
+func (r *notificationRepository) MarkAllAsRead(roleID, userID uint) error {
+	q := r.db.Model(&entity.Message{}).Where("is_read = ?", false)
+
+	switch roleID {
+	case utils.RoleUser:
+		q = q.Where("device_id IS NULL AND target_user_id = ?", userID)
+	case utils.RoleAdmin:
+		// mark all
+	default:
+		q = q.Where(
+			"device_id IS NOT NULL OR (device_id IS NULL AND (target_user_id IS NULL OR target_user_id = ?))",
+			userID,
+		)
+	}
+
+	return q.Update("is_read", true).Error
 }
 
 func (r *notificationRepository) GetStats() (NotificationStats, error) {

--- a/backend/services/auth.go
+++ b/backend/services/auth.go
@@ -53,7 +53,7 @@ func (a *authService) Register(input models.RegisterRequest) (*models.AuthRespon
 		return nil, err
 	}
 
-	token, err := a.jwtProvider.GenerateToken(user.ID)
+	token, err := a.jwtProvider.GenerateToken(user.ID, user.RoleID)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (a *authService) Login(input models.LoginRequest) (*models.AuthResponse, er
 		return nil, errors.New("invalid email or password")
 	}
 
-	token, err := a.jwtProvider.GenerateToken(user.ID)
+	token, err := a.jwtProvider.GenerateToken(user.ID, user.RoleID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/services/notification.go
+++ b/backend/services/notification.go
@@ -10,12 +10,13 @@ import (
 )
 
 type NotificationService interface {
-	GetAll() ([]models.NotificationResponse, error)
+	GetAll(roleID, userID uint) ([]models.NotificationResponse, error)
 	GetByID(id uint) (*models.NotificationResponse, error)
 	MarkAsRead(id uint) (*models.NotificationResponse, error)
-	MarkAllAsRead() error
+	MarkAllAsRead(roleID, userID uint) error
 	Delete(id uint) error
 	GetStats() (*models.NotificationStatsResponse, error)
+	CreateSystemNotification(message string, targetUserID uint) error
 }
 
 type notificationService struct {
@@ -26,8 +27,8 @@ func NewNotificationService(repo repositories.NotificationRepository) Notificati
 	return &notificationService{repo: repo}
 }
 
-func (s *notificationService) GetAll() ([]models.NotificationResponse, error) {
-	msgs, err := s.repo.FetchAll()
+func (s *notificationService) GetAll(roleID, userID uint) ([]models.NotificationResponse, error) {
+	msgs, err := s.repo.FetchAll(roleID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -71,8 +72,8 @@ func (s *notificationService) MarkAsRead(id uint) (*models.NotificationResponse,
 	return &resp, nil
 }
 
-func (s *notificationService) MarkAllAsRead() error {
-	return s.repo.MarkAllAsRead()
+func (s *notificationService) MarkAllAsRead(roleID, userID uint) error {
+	return s.repo.MarkAllAsRead(roleID, userID)
 }
 
 func (s *notificationService) Delete(id uint) error {
@@ -99,14 +100,24 @@ func (s *notificationService) GetStats() (*models.NotificationStatsResponse, err
 	}, nil
 }
 
+func (s *notificationService) CreateSystemNotification(message string, targetUserID uint) error {
+	msg := &entity.Message{
+		Message:      message,
+		IsRead:       false,
+		TargetUserID: &targetUserID,
+	}
+	return s.repo.Create(msg)
+}
+
 func mapNotificationToResponse(msg *entity.Message) models.NotificationResponse {
 	resp := models.NotificationResponse{
-		ID:        msg.ID,
-		Message:   msg.Message,
-		IsRead:    msg.IsRead,
-		DeviceID:  msg.DeviceID,
-		CreatedAt: msg.CreatedAt.Format(time.RFC3339),
-		UpdatedAt: msg.UpdatedAt.Format(time.RFC3339),
+		ID:           msg.ID,
+		Message:      msg.Message,
+		IsRead:       msg.IsRead,
+		DeviceID:     msg.DeviceID,
+		TargetUserID: msg.TargetUserID,
+		CreatedAt:    msg.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:    msg.UpdatedAt.Format(time.RFC3339),
 	}
 	if msg.Device != nil {
 		d := mapDeviceToResponse(msg.Device)


### PR DESCRIPTION
- Add RoleID to JWT claims and inject into gin context via middleware
- Implement RequireRole middleware with role constants (Admin/User/Engineer/Technician)
- Restrict routes by role: meter/device (Admin+Engineer), waterlog (staff for read, Admin+Engineer for write), user management (Admin only), notification delete (Admin only)
- Add TargetUserID field to Message entity for user-targeted system notifications
- Extend notification service with CreateSystemNotification; send notification on login and maintain-log create
- Update notification filtering by role in repository (FetchAll, MarkAllAsRead)
- Standardise all error responses to {success, error: {message, detail}} format
- Update all controller tests to inject roleID into context