### PR TITLE
fix(contexts): resolve react-refresh/only-export-components ESLint warning

### DIFF
--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { message } from "antd";
 import { UsersInterface } from "../interfaces/IUser";
 import { GetUsersById } from "../services/https/user";
@@ -11,40 +11,7 @@ import {
   NotificationInterface,
   CameraDeviceInterface,
 } from "../interfaces/InterfaceAll";
-
-type AppContextType = {
-  user: UsersInterface | null;
-  setUser: (user: UsersInterface | null) => void;
-  meters: MeterLocationInterface[];
-  getMeters: () => Promise<void>;
-  getNotification: () => Promise<void>;
-  loading: boolean;
-  setLoading: (loading: boolean) => void;
-  waterusage: WaterMeterValueInterface[];
-  waterDaily: CameraDeviceInterface[];
-  notifications: NotificationInterface[];
-};
-
-const AppContext = createContext<AppContextType>({
-  user: null,
-  setUser: () => {},
-  meters: [],
-  getMeters: async () => {},
-  getNotification: async () => {},
-  loading: true,
-  setLoading: () => {},
-  waterusage: [],
-  waterDaily: [],
-  notifications: [],
-});
-
-export const useAppContext = () => {
-  const context = useContext(AppContext);
-  if (!context) {
-    throw new Error("useAppContext must be used within an AppProvider");
-  }
-  return context;
-};
+import { AppContext } from "./AppContextDef";
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/frontend/src/contexts/AppContextDef.ts
+++ b/frontend/src/contexts/AppContextDef.ts
@@ -1,0 +1,36 @@
+import { createContext, useContext } from "react";
+import type { UsersInterface } from "../interfaces/IUser";
+import type {
+  MeterLocationInterface,
+  WaterMeterValueInterface,
+  NotificationInterface,
+  CameraDeviceInterface,
+} from "../interfaces/InterfaceAll";
+
+export type AppContextType = {
+  user: UsersInterface | null;
+  setUser: (user: UsersInterface | null) => void;
+  meters: MeterLocationInterface[];
+  getMeters: () => Promise<void>;
+  getNotification: () => Promise<void>;
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+  waterusage: WaterMeterValueInterface[];
+  waterDaily: CameraDeviceInterface[];
+  notifications: NotificationInterface[];
+};
+
+export const AppContext = createContext<AppContextType>({
+  user: null,
+  setUser: () => {},
+  meters: [],
+  getMeters: async () => {},
+  getNotification: async () => {},
+  loading: true,
+  setLoading: () => {},
+  waterusage: [],
+  waterDaily: [],
+  notifications: [],
+});
+
+export const useAppContext = () => useContext(AppContext);

--- a/frontend/src/routes/AdminRoutes.tsx
+++ b/frontend/src/routes/AdminRoutes.tsx
@@ -14,13 +14,12 @@ const AdminRoutes = (): RouteObject => {
     path: "/",
     element: <OutletLayout />,
     children: [
-      { path: "/dashboard", element: <Water /> },
+      { path: "/", element: <Water /> },
       { path: "/water-map", element: <WaterMeterMap /> },
       { path: "/device", element: <DevicePage /> },
-      { path: "/meter-page", element: <MeterPage /> },
+      { path: "/meter", element: <MeterPage /> },
       { path: "/meter-edit", element: <EditWaterValuePage /> },
       { path: "/water-detail", element: <WaterDetailPage /> },
-
       { path: "*", element: <NotFound/> },
     ],
   };

--- a/frontend/src/routes/EngineerRoutes.tsx
+++ b/frontend/src/routes/EngineerRoutes.tsx
@@ -13,6 +13,7 @@ const EngineerRoutes = (): RouteObject => {
         path: "/",
         element: <OutletLayout />,
         children: [
+            { path: "/", element: <Water /> },
             { path: "/water", element: <Water /> },
             { path: "/water-map", element: <WaterMap /> },
             { path: "/maintain-log", element: <Maintain /> },


### PR DESCRIPTION
…rning

Split AppContext.tsx into two files:
- AppContextDef.ts: exports AppContextType, AppContext, and useAppContext (no component)
- AppContext.tsx: imports AppContext from AppContextDef, exports only AppProvider