### PR TITLE
feat(users): add user management page, role/position endpoints, and profile improvements

### DIFF
--- a/backend/config/models/user.go
+++ b/backend/config/models/user.go
@@ -30,3 +30,8 @@ type ChangePasswordRequest struct {
 	OldPassword string `json:"old_password" validate:"required"`
 	NewPassword string `json:"new_password" validate:"required,min=8,max=72"`
 }
+
+type UpdateRolePositionRequest struct {
+	RoleID     uint  `json:"role_id"     validate:"required,min=1"`
+	PositionID *uint `json:"position_id"`
+}

--- a/backend/config/utils/role.go
+++ b/backend/config/utils/role.go
@@ -8,9 +8,9 @@ import (
 
 const (
 	RoleAdmin      = uint(1)
-	RoleUser       = uint(2)
-	RoleEngineer   = uint(3)
-	RoleTechnician = uint(4)
+	RoleEngineer   = uint(2)
+	RoleTechnician = uint(3)
+	RoleUser       = uint(4)
 )
 
 // RequireRole aborts with 403 if the caller's role is not in the allowed list.

--- a/backend/controller/positions/position_controller.go
+++ b/backend/controller/positions/position_controller.go
@@ -1,0 +1,37 @@
+package positions
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/utils"
+	"github.com/watermeter/suth/repositories"
+)
+
+type PositionHandler struct {
+	positionRepo repositories.PositionRepository
+}
+
+func NewPositionHandler(router *gin.RouterGroup, positionRepo repositories.PositionRepository) *PositionHandler {
+	handler := &PositionHandler{positionRepo: positionRepo}
+	router.GET("/positions", handler.GetAll)
+	return handler
+}
+
+type positionResponse struct {
+	ID       uint   `json:"id"`
+	Position string `json:"position"`
+}
+
+func (h *PositionHandler) GetAll(c *gin.Context) {
+	data, err := h.positionRepo.FindAll()
+	if err != nil {
+		utils.NewError(c, http.StatusInternalServerError, utils.ErrInternalServer)
+		return
+	}
+	res := make([]positionResponse, len(data))
+	for i, p := range data {
+		res[i] = positionResponse{ID: p.ID, Position: p.Position}
+	}
+	utils.JSONSuccess(c, http.StatusOK, res)
+}

--- a/backend/controller/roles/role_controller.go
+++ b/backend/controller/roles/role_controller.go
@@ -1,0 +1,37 @@
+package roles
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/watermeter/suth/config/utils"
+	"github.com/watermeter/suth/repositories"
+)
+
+type RoleHandler struct {
+	roleRepo repositories.RoleRepository
+}
+
+func NewRoleHandler(router *gin.RouterGroup, roleRepo repositories.RoleRepository) *RoleHandler {
+	handler := &RoleHandler{roleRepo: roleRepo}
+	router.GET("/roles", handler.GetAll)
+	return handler
+}
+
+type roleResponse struct {
+	ID   uint   `json:"id"`
+	Role string `json:"role"`
+}
+
+func (h *RoleHandler) GetAll(c *gin.Context) {
+	data, err := h.roleRepo.FindAll()
+	if err != nil {
+		utils.NewError(c, http.StatusInternalServerError, utils.ErrInternalServer)
+		return
+	}
+	res := make([]roleResponse, len(data))
+	for i, r := range data {
+		res[i] = roleResponse{ID: r.ID, Role: r.Role}
+	}
+	utils.JSONSuccess(c, http.StatusOK, res)
+}

--- a/backend/controller/users/user_controller.go
+++ b/backend/controller/users/user_controller.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -30,8 +31,10 @@ func NewUserHandler(router *gin.RouterGroup, userService services.UserService) *
 	user.GET("", adminOrEngineer, handler.GetAllUsers)
 	user.GET("/:id", handler.GetProfile)
 	user.PUT("/:id", handler.UpdateProfile)
+	user.PUT("/:id/assignment", adminOnly, handler.UpdateRoleAndPosition)
 	user.PUT("/:id/change-password", handler.ChangePassword)
-	user.DELETE("/:id", adminOnly, handler.DeleteUser)
+	user.DELETE("/me", handler.DeleteUser)
+	user.DELETE("/:id", adminOnly, handler.AdminDeleteUser)
 
 	return handler
 }
@@ -124,6 +127,36 @@ func (h *UserHandler) DeleteUser(c *gin.Context) {
 	utils.JSONSuccess(c, http.StatusNoContent, nil)
 }
 
+func (h *UserHandler) AdminDeleteUser(c *gin.Context) {
+	targetID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || targetID <= 0 {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidID)
+		return
+	}
+
+	callerID, exists := utils.GetUserIDFromContext(c)
+	if !exists {
+		utils.NewError(c, http.StatusUnauthorized, utils.ErrMissingID)
+		return
+	}
+
+	if uint(targetID) == callerID {
+		utils.NewError(c, http.StatusForbidden, utils.ErrCannotBeDeleted)
+		return
+	}
+
+	if err := h.userService.DeleteUser(uint(targetID)); err != nil {
+		if err.Error() == "user not found" {
+			utils.NewError(c, http.StatusNotFound, utils.ErrNotFound)
+			return
+		}
+		utils.NewError(c, http.StatusBadRequest, utils.ErrDeleteFailed)
+		return
+	}
+
+	utils.JSONSuccess(c, http.StatusNoContent, nil)
+}
+
 func (h *UserHandler) GetAllUsers(c *gin.Context) {
 	users, err := h.userService.GetAllUsers()
 	if err != nil {
@@ -132,4 +165,35 @@ func (h *UserHandler) GetAllUsers(c *gin.Context) {
 	}
 
 	utils.JSONSuccess(c, http.StatusOK, users)
+}
+
+func (h *UserHandler) UpdateRoleAndPosition(c *gin.Context) {
+	targetID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || targetID <= 0 {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidID)
+		return
+	}
+
+	var payload models.UpdateRolePositionRequest
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidPayload)
+		return
+	}
+
+	if err := h.validate.Struct(payload); err != nil {
+		utils.JSONError(c, http.StatusBadRequest, utils.ErrValidation.Error(), err.Error())
+		return
+	}
+
+	updated, err := h.userService.UpdateRoleAndPosition(uint(targetID), payload)
+	if err != nil {
+		if err.Error() == "user not found" {
+			utils.NewError(c, http.StatusNotFound, utils.ErrNotFound)
+			return
+		}
+		utils.NewError(c, http.StatusBadRequest, utils.ErrUpdateFailed)
+		return
+	}
+
+	utils.JSONSuccess(c, http.StatusOK, updated)
 }

--- a/backend/controller/users/user_controller_test.go
+++ b/backend/controller/users/user_controller_test.go
@@ -14,11 +14,12 @@ import (
 )
 
 type mockUserService struct {
-	getProfileFn     func(userID uint) (*models.UserResponse, error)
-	updateProfileFn  func(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error)
-	changePasswordFn func(userID uint, input models.ChangePasswordRequest) error
-	deleteUserFn     func(userID uint) error
-	getAllUsersFn     func() ([]models.UserResponse, error)
+	getProfileFn             func(userID uint) (*models.UserResponse, error)
+	updateProfileFn          func(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error)
+	updateRoleAndPositionFn  func(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error)
+	changePasswordFn         func(userID uint, input models.ChangePasswordRequest) error
+	deleteUserFn             func(userID uint) error
+	getAllUsersFn             func() ([]models.UserResponse, error)
 }
 
 func (m *mockUserService) GetProfile(userID uint) (*models.UserResponse, error) {
@@ -26,6 +27,9 @@ func (m *mockUserService) GetProfile(userID uint) (*models.UserResponse, error) 
 }
 func (m *mockUserService) UpdateProfile(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error) {
 	return m.updateProfileFn(userID, input)
+}
+func (m *mockUserService) UpdateRoleAndPosition(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error) {
+	return m.updateRoleAndPositionFn(targetUserID, input)
 }
 func (m *mockUserService) ChangePassword(userID uint, input models.ChangePasswordRequest) error {
 	return m.changePasswordFn(userID, input)
@@ -243,12 +247,74 @@ func TestChangePassword_ServiceError(t *testing.T) {
 	assertStatusUser(t, http.StatusBadRequest, w.Code)
 }
 
-// --- DeleteUser ---
+// --- UpdateRoleAndPosition ---
+
+func TestUpdateRoleAndPosition_InvalidID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/abc/assignment", jsonBodyUser(t, map[string]any{})))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateRoleAndPosition_InvalidJSON(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/assignment", bytes.NewBufferString("{bad}")))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateRoleAndPosition_ValidationError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	// role_id = 0 ไม่ผ่าน validate:"required,min=1"
+	body := jsonBodyUser(t, map[string]any{"role_id": 0})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/assignment", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateRoleAndPosition_NotFound(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		updateRoleAndPositionFn: func(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error) {
+			return nil, errors.New("user not found")
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.UpdateRolePositionRequest{RoleID: 2})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/99/assignment", body))
+	assertStatusUser(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdateRoleAndPosition_Success(t *testing.T) {
+	posID := uint(1)
+	r := setupUserRouter(&mockUserService{
+		updateRoleAndPositionFn: func(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error) {
+			return &models.UserResponse{ID: targetUserID, RoleID: input.RoleID, PositionID: input.PositionID}, nil
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.UpdateRolePositionRequest{RoleID: 3, PositionID: &posID})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/2/assignment", body))
+	assertStatusUser(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateRoleAndPosition_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		updateRoleAndPositionFn: func(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error) {
+			return nil, errors.New("update failed")
+		},
+	}, &testUID)
+	body := jsonBodyUser(t, models.UpdateRolePositionRequest{RoleID: 2})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonReqUser(t, http.MethodPut, "/api/v1/users/1/assignment", body))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+// --- DeleteUser (self-delete via DELETE /me) ---
 
 func TestDeleteUser_MissingUserID(t *testing.T) {
 	r := setupUserRouter(&mockUserService{}, nil)
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/me", nil))
 	assertStatusUser(t, http.StatusUnauthorized, w.Code)
 }
 
@@ -257,7 +323,7 @@ func TestDeleteUser_Success(t *testing.T) {
 		deleteUserFn: func(userID uint) error { return nil },
 	}, &testUID)
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/me", nil))
 	assertStatusUser(t, http.StatusNoContent, w.Code)
 }
 
@@ -266,6 +332,57 @@ func TestDeleteUser_ServiceError(t *testing.T) {
 		deleteUserFn: func(userID uint) error { return errors.New("delete failed") },
 	}, &testUID)
 	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/me", nil))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+// --- AdminDeleteUser (DELETE /:id) ---
+
+func TestAdminDeleteUser_InvalidID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/abc", nil))
+	assertStatusUser(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminDeleteUser_MissingUserID(t *testing.T) {
+	r := setupUserRouter(&mockUserService{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/2", nil))
+	assertStatusUser(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAdminDeleteUser_SelfDelete(t *testing.T) {
+	// testUID = 1, ลบ /users/1 → ลบตัวเอง → 403
+	r := setupUserRouter(&mockUserService{}, &testUID)
+	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil))
+	assertStatusUser(t, http.StatusForbidden, w.Code)
+}
+
+func TestAdminDeleteUser_Success(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		deleteUserFn: func(userID uint) error { return nil },
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/2", nil))
+	assertStatusUser(t, http.StatusNoContent, w.Code)
+}
+
+func TestAdminDeleteUser_NotFound(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		deleteUserFn: func(userID uint) error { return errors.New("user not found") },
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/99", nil))
+	assertStatusUser(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminDeleteUser_ServiceError(t *testing.T) {
+	r := setupUserRouter(&mockUserService{
+		deleteUserFn: func(userID uint) error { return errors.New("db error") },
+	}, &testUID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/users/2", nil))
 	assertStatusUser(t, http.StatusBadRequest, w.Code)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/watermeter/suth/controller/maintainlog"
 	"github.com/watermeter/suth/controller/meter"
 	"github.com/watermeter/suth/controller/notification"
+	"github.com/watermeter/suth/controller/positions"
+	"github.com/watermeter/suth/controller/roles"
 	"github.com/watermeter/suth/controller/users"
 	"github.com/watermeter/suth/controller/waterlog"
 	"github.com/watermeter/suth/middlewares"
@@ -75,6 +77,13 @@ func main() {
 
 	genderRepository := repositories.NewGenderRepository(db)
 	genders.NewGenderHandler(privateRouter, genderRepository)
+
+	roleRepository := repositories.NewRoleRepository(db)
+	roles.NewRoleHandler(privateRouter, roleRepository)
+
+	positionRepository := repositories.NewPositionRepository(db)
+	positions.NewPositionHandler(privateRouter, positionRepository)
+
 	meter.NewMeterHandler(privateRouter, locationService)
 	device.NewDeviceHandler(privateRouter, deviceService)
 	maintainlog.NewMaintainLogHandler(privateRouter, maintainLogService, notificationService)

--- a/backend/repositories/position_repository.go
+++ b/backend/repositories/position_repository.go
@@ -1,0 +1,26 @@
+package repositories
+
+import (
+	"github.com/watermeter/suth/entity"
+	"gorm.io/gorm"
+)
+
+type PositionRepository interface {
+	FindAll() ([]entity.Position, error)
+}
+
+type positionRepository struct {
+	db *gorm.DB
+}
+
+func NewPositionRepository(db *gorm.DB) PositionRepository {
+	return &positionRepository{db: db}
+}
+
+func (r *positionRepository) FindAll() ([]entity.Position, error) {
+	var positions []entity.Position
+	if err := r.db.Find(&positions).Error; err != nil {
+		return nil, err
+	}
+	return positions, nil
+}

--- a/backend/repositories/role_repository.go
+++ b/backend/repositories/role_repository.go
@@ -1,0 +1,26 @@
+package repositories
+
+import (
+	"github.com/watermeter/suth/entity"
+	"gorm.io/gorm"
+)
+
+type RoleRepository interface {
+	FindAll() ([]entity.Role, error)
+}
+
+type roleRepository struct {
+	db *gorm.DB
+}
+
+func NewRoleRepository(db *gorm.DB) RoleRepository {
+	return &roleRepository{db: db}
+}
+
+func (r *roleRepository) FindAll() ([]entity.Role, error) {
+	var roles []entity.Role
+	if err := r.db.Find(&roles).Error; err != nil {
+		return nil, err
+	}
+	return roles, nil
+}

--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -13,6 +13,7 @@ import (
 type UserService interface {
 	GetProfile(userID uint) (*models.UserResponse, error)
 	UpdateProfile(userID uint, input models.UpdateUserRequest) (*models.UserResponse, error)
+	UpdateRoleAndPosition(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error)
 	ChangePassword(userID uint, input models.ChangePasswordRequest) error
 	DeleteUser(userID uint) error
 	GetAllUsers() ([]models.UserResponse, error)
@@ -76,6 +77,26 @@ func (s *userService) UpdateProfile(userID uint, input models.UpdateUserRequest)
 	}
 
 	user.UpdatedAt = time.Now().UTC()
+	if err := s.userRepo.Update(user); err != nil {
+		return nil, err
+	}
+
+	return mapUserToResponse(user), nil
+}
+
+func (s *userService) UpdateRoleAndPosition(targetUserID uint, input models.UpdateRolePositionRequest) (*models.UserResponse, error) {
+	user, err := s.userRepo.FindByID(targetUserID)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, errors.New("user not found")
+	}
+
+	user.RoleID = input.RoleID
+	user.PositionID = input.PositionID
+	user.UpdatedAt = time.Now().UTC()
+
 	if err := s.userRepo.Update(user); err != nil {
 		return nil, err
 	}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+export function useTheme() {
+  const [dark, setDark] = useState<boolean>(
+    () => localStorage.getItem("theme") === "dark"
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  }, [dark]);
+
+  const toggle = () => setDark((v) => !v);
+
+  return { dark, toggle };
+}

--- a/frontend/src/interfaces/IUser.ts
+++ b/frontend/src/interfaces/IUser.ts
@@ -9,6 +9,7 @@ export interface UsersInterface {
   gender_id?: number;
   role_id?: number;
   position_id?: number;
+  profile_image?: string;
   Password?: string;
   Gender?: GenderInterface;
 }

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { message } from "antd";
-import { Camera, Save, KeyRound, Eye, EyeOff } from "lucide-react";
-import { GetUsersById, UpdateUsersById } from "../../services/https/user";
+import { Camera, Save, KeyRound, Eye, EyeOff, Trash2, TriangleAlert } from "lucide-react";
+import { GetUsersById, UpdateUsersById, DeleteUsersByAdmin } from "../../services/https/user";
 import { ChangePassword } from "../../services/https/sign";
 import { GetGender } from "../../services/https/api";
 
@@ -10,10 +11,18 @@ const INPUT =
 
 const LABEL = "block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1";
 
+const MONTHS = ["ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."];
+const THIS_YEAR = new Date().getFullYear();
+const YEARS = Array.from({ length: THIS_YEAR - 1930 + 1 }, (_, i) => THIS_YEAR - i);
+
 type Gender = { id: number; gender: string };
 
 export default function ProfilePage() {
+  const navigate = useNavigate();
   const [msgApi, ctx] = message.useMessage();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDeleteBtn, setShowDeleteBtn] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
   const id = localStorage.getItem("id") ?? "";
 
@@ -103,17 +112,43 @@ export default function ProfilePage() {
     }
   };
 
+  const handleDeleteAccount = async () => {
+    setDeleting(true);
+    const res = await DeleteUsersByAdmin();
+    setDeleting(false);
+    if (res?.status === 200 || res?.status === 204) {
+      msgApi.success("ลบบัญชีสำเร็จ");
+      localStorage.clear();
+      setTimeout(() => navigate("/"), 1000);
+    } else {
+      msgApi.error(res?.data?.error?.message ?? "เกิดข้อผิดพลาด");
+      setShowDeleteModal(false);
+    }
+  };
+
+  const bYear  = form.birthday.slice(0, 4);
+  const bMonth = form.birthday.slice(5, 7);
+  const bDay   = form.birthday.slice(8, 10);
+  const daysInMonth = bYear && bMonth ? new Date(Number(bYear), Number(bMonth), 0).getDate() : 31;
+
+  const updateBirthday = (y: string, m: string, d: string) => {
+    if (!y || !m || !d) { setForm((f) => ({ ...f, birthday: "" })); return; }
+    const maxDay = new Date(Number(y), Number(m), 0).getDate();
+    const safeDay = String(Math.min(Number(d), maxDay)).padStart(2, "0");
+    setForm((f) => ({ ...f, birthday: `${y}-${m}-${safeDay}` }));
+  };
+
   const isFormChanged = JSON.stringify(form) !== JSON.stringify(initialForm);
   const initials = (form.first_name[0] ?? form.email[0] ?? "U").toUpperCase();
 
   return (
-    <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-6">
+    <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-4 sm:p-6">
       {ctx}
-      <div className="max-w-2xl mx-auto space-y-6">
+      <div className="max-w-2xl mx-auto space-y-4 sm:space-y-6">
 
         {/* ——— Avatar ——— */}
-        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-6 flex items-center gap-5">
-          <div className="relative">
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5 sm:p-6 flex flex-col sm:flex-row items-center gap-4 sm:gap-5">
+          <div className="relative shrink-0">
             {form.profile_image ? (
               <img src={form.profile_image} alt="avatar"
                 className="w-20 h-20 rounded-full object-cover ring-2 ring-teal-500/30" />
@@ -130,7 +165,7 @@ export default function ProfilePage() {
             </button>
             <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImage} />
           </div>
-          <div>
+          <div className="text-center sm:text-left">
             <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
               {form.first_name} {form.last_name}
             </p>
@@ -140,9 +175,9 @@ export default function ProfilePage() {
         </div>
 
         {/* ——— Personal info ——— */}
-        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-6">
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5 sm:p-6">
           <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-5">ข้อมูลส่วนตัว</h2>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className={LABEL}>ชื่อ</label>
               <input className={INPUT} value={form.first_name}
@@ -153,15 +188,45 @@ export default function ProfilePage() {
               <input className={INPUT} value={form.last_name}
                 onChange={(e) => setForm((f) => ({ ...f, last_name: e.target.value }))} />
             </div>
-            <div className="col-span-2">
+            <div className="col-span-1 sm:col-span-2">
               <label className={LABEL}>อีเมล</label>
               <input type="email" className={INPUT} value={form.email}
                 onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} />
             </div>
             <div>
               <label className={LABEL}>วันเกิด</label>
-              <input type="date" className={INPUT} value={form.birthday}
-                onChange={(e) => setForm((f) => ({ ...f, birthday: e.target.value }))} />
+              <div className="grid grid-cols-3 gap-2">
+                <select
+                  className={INPUT}
+                  value={bDay}
+                  onChange={(e) => updateBirthday(bYear, bMonth, e.target.value)}
+                >
+                  <option value="">วัน</option>
+                  {Array.from({ length: daysInMonth }, (_, i) => String(i + 1).padStart(2, "0")).map((d) => (
+                    <option key={d} value={d}>{Number(d)}</option>
+                  ))}
+                </select>
+                <select
+                  className={INPUT}
+                  value={bMonth}
+                  onChange={(e) => updateBirthday(bYear, e.target.value, bDay)}
+                >
+                  <option value="">เดือน</option>
+                  {MONTHS.map((name, i) => (
+                    <option key={i} value={String(i + 1).padStart(2, "0")}>{name}</option>
+                  ))}
+                </select>
+                <select
+                  className={INPUT}
+                  value={bYear}
+                  onChange={(e) => updateBirthday(e.target.value, bMonth, bDay)}
+                >
+                  <option value="">ปี</option>
+                  {YEARS.map((y) => (
+                    <option key={y} value={String(y)}>{y}</option>
+                  ))}
+                </select>
+              </div>
             </div>
             <div>
               <label className={LABEL}>เพศ</label>
@@ -190,7 +255,7 @@ export default function ProfilePage() {
         </div>
 
         {/* ——— Change password ——— */}
-        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-6">
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5 sm:p-6">
           <div className="flex items-center gap-2 mb-5">
             <KeyRound size={16} className="text-gray-400" />
             <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">เปลี่ยนรหัสผ่าน</h2>
@@ -232,7 +297,73 @@ export default function ProfilePage() {
           </div>
         </div>
 
+        {/* ——— Danger Zone ——— */}
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-red-100 dark:border-red-900/40 p-5 sm:p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <TriangleAlert size={16} className="text-red-500" />
+            <h2 className="text-sm font-semibold text-red-600 dark:text-red-400">พื้นที่อันตราย</h2>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4 leading-relaxed">
+            การลบบัญชีจะลบข้อมูลทั้งหมดของคุณออกจากระบบถาวร และไม่สามารถกู้คืนได้
+          </p>
+          <button
+            onClick={() => setShowDeleteBtn((v) => !v)}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors bg-transparent cursor-pointer"
+          >
+            <TriangleAlert size={14} />
+            {showDeleteBtn ? "ซ่อนตัวเลือก" : "จัดการบัญชี"}
+          </button>
+          {showDeleteBtn && (
+            <div className="mt-3 pt-3 border-t border-red-100 dark:border-red-900/30">
+              <button
+                onClick={() => setShowDeleteModal(true)}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors bg-transparent cursor-pointer"
+              >
+                <Trash2 size={14} />
+                ลบบัญชีของฉัน
+              </button>
+            </div>
+          )}
+        </div>
+
       </div>
+
+      {/* ——— Delete Confirmation Modal ——— */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/40 backdrop-blur-sm">
+          <div className="w-full sm:max-w-sm bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl border border-gray-100 dark:border-gray-800 p-6 pb-8 sm:pb-6">
+            <div className="w-10 h-1 rounded-full bg-gray-200 dark:bg-gray-700 mx-auto mb-5 sm:hidden" />
+            <div className="flex items-start gap-4 mb-5">
+              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center shrink-0">
+                <Trash2 size={18} className="text-red-500" />
+              </div>
+              <div>
+                <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">ยืนยันการลบบัญชี</h2>
+                <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
+                  บัญชีของ <span className="font-medium text-gray-700 dark:text-gray-200">{form.email}</span> จะถูกลบออกจากระบบถาวร การกระทำนี้ไม่สามารถย้อนกลับได้
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowDeleteModal(false)}
+                disabled={deleting}
+                className="px-4 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border-0 bg-transparent cursor-pointer disabled:opacity-50"
+              >
+                ยกเลิก
+              </button>
+              <button
+                onClick={handleDeleteAccount}
+                disabled={deleting}
+                className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white bg-red-500 hover:bg-red-600 disabled:opacity-60 transition-colors border-0 cursor-pointer"
+              >
+                <Trash2 size={14} />
+                {deleting ? "กำลังลบ..." : "ลบบัญชี"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/user/UserPage.tsx
+++ b/frontend/src/pages/user/UserPage.tsx
@@ -1,10 +1,402 @@
-function UserPage() { 
+import { useEffect, useState } from "react";
+import { message } from "antd";
+import { Search, Pencil, Trash2, X, Users, Save } from "lucide-react";
+import { GetUsers, DeleteUsersById, UpdateUserAssignment } from "../../services/https/user";
+import { GetRoles, GetPositions } from "../../services/https/api";
+import { UsersInterface } from "../../interfaces/IUser";
 
+const SELECT =
+  "w-full h-10 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20";
+
+const LABEL = "block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1";
+
+const ROLE_COLORS: Record<number, string> = {
+  1: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  2: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  3: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+  4: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+};
+
+type Role = { id: number; role: string };
+type Position = { id: number; position: string };
+type EditState = { role_id: number | ""; position_id: number | "" };
+
+const ROLE_ENGINEER = 2;
+
+export default function UserPage() {
+  const currentId     = Number(localStorage.getItem("id"));
+  const currentRoleId = Number(localStorage.getItem("role_id"));
+
+  const canDelete = (u: UsersInterface) =>
+    currentRoleId !== ROLE_ENGINEER && u.id !== currentId;
+
+  const [msgApi, ctx] = message.useMessage();
+  const [users, setUsers] = useState<UsersInterface[]>([]);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const [editUser, setEditUser] = useState<UsersInterface | null>(null);
+  const [editState, setEditState] = useState<EditState>({ role_id: "", position_id: "" });
+  const [saving, setSaving] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState<UsersInterface | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    const res = await GetUsers();
+    setLoading(false);
+    if (res?.status === 200) setUsers(res.data?.data ?? res.data ?? []);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+    GetRoles().then((res) => {
+      if (res?.status === 200) setRoles(res.data?.data ?? res.data ?? []);
+    });
+    GetPositions().then((res) => {
+      if (res?.status === 200) setPositions(res.data?.data ?? res.data ?? []);
+    });
+  }, []);
+
+  const openEdit = (user: UsersInterface) => {
+    setEditUser(user);
+    setEditState({ role_id: user.role_id ?? "", position_id: user.position_id ?? "" });
+  };
+
+  const handleSave = async () => {
+    if (!editUser?.id || editState.role_id === "") return;
+    setSaving(true);
+    const res = await UpdateUserAssignment(String(editUser.id), {
+      role_id: editState.role_id as number,
+      position_id: editState.position_id !== "" ? (editState.position_id as number) : null,
+    });
+    setSaving(false);
+    if (res?.status === 200) {
+      msgApi.success("บันทึกข้อมูลสำเร็จ");
+      setEditUser(null);
+      fetchUsers();
+    } else {
+      msgApi.error(res?.data?.error?.message ?? "เกิดข้อผิดพลาด");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget?.id) return;
+    setDeleting(true);
+    const res = await DeleteUsersById(String(deleteTarget.id));
+    setDeleting(false);
+    if (res?.status === 200) {
+      msgApi.success("ลบผู้ใช้สำเร็จ");
+      setDeleteTarget(null);
+      fetchUsers();
+    } else {
+      msgApi.error(res?.data?.error?.message ?? "เกิดข้อผิดพลาด");
+    }
+  };
+
+  const roleName = (id?: number) => roles.find((r) => r.id === id)?.role;
+  const positionName = (id?: number) => positions.find((p) => p.id === id)?.position;
+
+  const filtered = users.filter((u) => {
+    const q = search.toLowerCase();
     return (
-        <div className="text-xl text-red-600">
-             User Management Page
+      `${u.first_name} ${u.last_name}`.toLowerCase().includes(q) ||
+      (u.email ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-4 sm:p-6">
+      {ctx}
+      <div className="max-w-6xl mx-auto space-y-4 sm:space-y-5">
+
+        {/* ——— Header ——— */}
+        <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <div className="w-9 h-9 rounded-xl bg-teal-500/10 flex items-center justify-center shrink-0">
+              <Users size={18} className="text-teal-600" />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-base font-semibold text-gray-900 dark:text-gray-100">จัดการผู้ใช้</h1>
+              <p className="text-xs text-gray-500 dark:text-gray-400">ทั้งหมด {users.length} คน</p>
+            </div>
+          </div>
+          <div className="relative w-full sm:w-64 shrink-0">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+            <input
+              className="w-full h-9 pl-9 pr-3 text-sm bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
+              placeholder="ค้นหาชื่อหรืออีเมล..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
         </div>
-    )
+
+        {/* ——— Loading / Empty ——— */}
+        {loading ? (
+          <div className="flex items-center justify-center h-48 text-sm text-gray-400">กำลังโหลด...</div>
+        ) : filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-48 text-sm text-gray-400">ไม่พบผู้ใช้</div>
+        ) : (
+          <>
+            {/* ——— Mobile: cards ——— */}
+            <div className="flex flex-col gap-3 md:hidden">
+              {filtered.map((u) => (
+                <div
+                  key={u.id}
+                  className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <Avatar user={u} size={10} />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                        {u.first_name} {u.last_name}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">{u.email ?? "—"}</p>
+                      <div className="flex flex-wrap items-center gap-2 mt-2">
+                        {u.role_id ? (
+                          <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${ROLE_COLORS[u.role_id] ?? "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"}`}>
+                            {roleName(u.role_id) ?? "—"}
+                          </span>
+                        ) : null}
+                        {positionName(u.position_id) && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            {positionName(u.position_id)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => openEdit(u)}
+                        title="แก้ไข"
+                        className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      {canDelete(u) && (
+                        <button
+                          onClick={() => setDeleteTarget(u)}
+                          title="ลบ"
+                          className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* ——— Desktop: table ——— */}
+            <div className="hidden md:block bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-100 dark:border-gray-800">
+                      {["ผู้ใช้", "อีเมล", "บทบาท", "ตำแหน่ง", ""].map((h, i) => (
+                        <th
+                          key={i}
+                          className={`px-5 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide ${i < 4 ? "text-left" : ""}`}
+                        >
+                          {h}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-50 dark:divide-gray-800">
+                    {filtered.map((u) => (
+                      <tr key={u.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                        <td className="px-5 py-3.5">
+                          <div className="flex items-center gap-3">
+                            <Avatar user={u} size={8} />
+                            <span className="font-medium text-gray-900 dark:text-gray-100">
+                              {u.first_name} {u.last_name}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-5 py-3.5 text-gray-500 dark:text-gray-400">{u.email ?? "—"}</td>
+                        <td className="px-5 py-3.5">
+                          {u.role_id ? (
+                            <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${ROLE_COLORS[u.role_id] ?? "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"}`}>
+                              {roleName(u.role_id) ?? "—"}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400">—</span>
+                          )}
+                        </td>
+                        <td className="px-5 py-3.5 text-gray-500 dark:text-gray-400">
+                          {positionName(u.position_id) ?? "—"}
+                        </td>
+                        <td className="px-5 py-3.5">
+                          <div className="flex items-center justify-end gap-1">
+                            <button
+                              onClick={() => openEdit(u)}
+                              title="แก้ไข"
+                              className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                            >
+                              <Pencil size={14} />
+                            </button>
+                            {canDelete(u) && (
+                              <button
+                                onClick={() => setDeleteTarget(u)}
+                                title="ลบ"
+                                className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                              >
+                                <Trash2 size={14} />
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ——— Edit Modal ——— */}
+      {editUser && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/40 backdrop-blur-sm">
+          <div className="w-full sm:max-w-sm bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl border border-gray-100 dark:border-gray-800">
+            {/* drag handle on mobile */}
+            <div className="flex justify-center pt-3 pb-1 sm:hidden">
+              <div className="w-10 h-1 rounded-full bg-gray-200 dark:bg-gray-700" />
+            </div>
+
+            <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800">
+              <div className="flex items-center gap-3">
+                <Avatar user={editUser} size={9} />
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 leading-tight">
+                    {editUser.first_name} {editUser.last_name}
+                  </p>
+                  <p className="text-xs text-gray-400 truncate max-w-[160px]">{editUser.email}</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setEditUser(null)}
+                className="w-7 h-7 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border-0 bg-transparent cursor-pointer shrink-0"
+              >
+                <X size={15} />
+              </button>
+            </div>
+
+            <div className="px-5 py-5 space-y-4">
+              <div>
+                <label className={LABEL}>บทบาท</label>
+                <select
+                  className={SELECT}
+                  value={editState.role_id}
+                  onChange={(e) => setEditState((s) => ({ ...s, role_id: Number(e.target.value) }))}
+                >
+                  <option value="">-- เลือกบทบาท --</option>
+                  {roles.map((r) => (
+                    <option key={r.id} value={r.id}>{r.role}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={LABEL}>ตำแหน่ง</label>
+                <select
+                  className={SELECT}
+                  value={editState.position_id}
+                  onChange={(e) =>
+                    setEditState((s) => ({ ...s, position_id: e.target.value !== "" ? Number(e.target.value) : "" }))
+                  }
+                >
+                  <option value="">-- ไม่ระบุตำแหน่ง --</option>
+                  {positions.map((p) => (
+                    <option key={p.id} value={p.id}>{p.position}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 px-5 py-4 border-t border-gray-100 dark:border-gray-800">
+              <button
+                onClick={() => setEditUser(null)}
+                className="px-4 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border-0 bg-transparent cursor-pointer"
+              >
+                ยกเลิก
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving || editState.role_id === ""}
+                className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-60 transition-colors border-0 cursor-pointer"
+              >
+                <Save size={14} />
+                {saving ? "กำลังบันทึก..." : "บันทึก"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ——— Delete Confirmation Modal ——— */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/40 backdrop-blur-sm">
+          <div className="w-full sm:max-w-sm bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-xl border border-gray-100 dark:border-gray-800 p-5">
+            {/* drag handle on mobile */}
+            <div className="flex justify-center -mt-1 mb-4 sm:hidden">
+              <div className="w-10 h-1 rounded-full bg-gray-200 dark:bg-gray-700" />
+            </div>
+
+            <div className="flex items-start gap-4">
+              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center shrink-0">
+                <Trash2 size={18} className="text-red-500" />
+              </div>
+              <div>
+                <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">ลบผู้ใช้</h2>
+                <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
+                  ต้องการลบ{" "}
+                  <span className="font-medium text-gray-700 dark:text-gray-200">
+                    {deleteTarget.first_name} {deleteTarget.last_name}
+                  </span>{" "}
+                  ออกจากระบบ? การกระทำนี้ไม่สามารถย้อนกลับได้
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-5">
+              <button
+                onClick={() => setDeleteTarget(null)}
+                className="px-4 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border-0 bg-transparent cursor-pointer"
+              >
+                ยกเลิก
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="px-5 py-2 rounded-lg text-sm font-semibold text-white bg-red-500 hover:bg-red-600 disabled:opacity-60 transition-colors border-0 cursor-pointer"
+              >
+                {deleting ? "กำลังลบ..." : "ลบผู้ใช้"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
-export default UserPage;
+function Avatar({ user, size }: { user: UsersInterface; size: number }) {
+  const initials = ((user.first_name?.[0] ?? "") + (user.last_name?.[0] ?? "")).toUpperCase() || "U";
+  const cls = `w-${size} h-${size} rounded-full object-cover shrink-0`;
+
+  if (user.profile_image) {
+    return <img src={user.profile_image} alt={initials} className={cls} />;
+  }
+
+  return (
+    <div className={`${cls} bg-teal-500 flex items-center justify-center text-white text-xs font-bold`}>
+      {initials}
+    </div>
+  );
+}

--- a/frontend/src/services/https/api.ts
+++ b/frontend/src/services/https/api.ts
@@ -19,3 +19,17 @@ export async function GetGender() {
     .then((res) => res)
     .catch((e) => e.response);
 }
+
+export async function GetRoles() {
+  return await axios
+    .get(`${apiUrl}/roles`, authHeader())
+    .then((res) => res)
+    .catch((e) => e.response);
+}
+
+export async function GetPositions() {
+  return await axios
+    .get(`${apiUrl}/positions`, authHeader())
+    .then((res) => res)
+    .catch((e) => e.response);
+}

--- a/frontend/src/services/https/user.ts
+++ b/frontend/src/services/https/user.ts
@@ -25,9 +25,23 @@ export async function UpdateUsersById(id: string, data: UsersInterface) {
         .catch((e) => e.response);
 }
 
+export async function DeleteUsersByAdmin() {
+    return await axios
+        .delete(`${apiUrl}/users/me`, authHeader())
+        .then((res) => res)
+        .catch((e) => e.response);
+}
+
 export async function DeleteUsersById(id: string) {
     return await axios
-        .delete(`${apiUrl}/user/${id}`, authHeader())
+        .delete(`${apiUrl}/users/${id}`, authHeader())
+        .then((res) => res)
+        .catch((e) => e.response);
+}
+
+export async function UpdateUserAssignment(id: string, data: { role_id: number; position_id?: number | null }) {
+    return await axios
+        .put(`${apiUrl}/users/${id}/assignment`, data, authHeader())
         .then((res) => res)
         .catch((e) => e.response);
 }


### PR DESCRIPTION
…rofile improvements

- Add UserPage with responsive table/card layout, role-based delete restrictions
- Add backend GET /roles and GET /positions endpoints
- Add PUT /users/:id/assignment for admin role/position updates
- Add DELETE /users/:id (admin, by URL param) and DELETE /users/me (self)
- Add profile_image support to UsersInterface
- Refactor ProfilePage: responsive layout, birthday dropdowns, delete account
- Add danger zone toggle to hide delete button until revealed
- Add useTheme hook