### PR TITLE
feat(water,maintain,user): add manual readings, maintain reporting, dashboard, and access controls

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,3 +5,4 @@
 .env.production
 CLAUDE.md
 SKILL.md
+ีuploads

--- a/backend/config/models/maintain_log.go
+++ b/backend/config/models/maintain_log.go
@@ -8,6 +8,7 @@ type MaintainLogRequest struct {
 	CloseAt      *time.Time `json:"close_at"`
 	LocationID   *uint      `json:"location_id"`
 	StatusID     *uint      `json:"status_id"`
+	ImagePath    string     `json:"image_path"`
 }
 
 type UpdateMaintainLogRequest struct {
@@ -29,6 +30,7 @@ type MaintainLogResponse struct {
 	Title        string             `json:"title"`
 	LocationText string             `json:"location_text"`
 	CloseAt      string             `json:"close_at,omitempty"`
+	ImagePath    string             `json:"image_path,omitempty"`
 	LocationID   *uint              `json:"location_id"`
 	Location     *LocationResponse  `json:"location,omitempty"`
 	StatusID     *uint              `json:"status_id"`

--- a/backend/config/models/water_meter_value.go
+++ b/backend/config/models/water_meter_value.go
@@ -9,6 +9,7 @@ type WaterMeterValueRequest struct {
 	Note            string     `json:"note"`
 	ImagePath       string     `json:"image_path"`
 	DeviceID        uint       `json:"device_id"         validate:"required"`
+	StatusID        uint       `json:"status_id"` // 0 = ใช้ค่า default (pending)
 }
 
 type UpdateWaterMeterValueRequest struct {

--- a/backend/config/postgres/migrate.go
+++ b/backend/config/postgres/migrate.go
@@ -240,35 +240,85 @@ func seedMessage(database *gorm.DB) {
 }
 
 func seedWaterMeterValues(database *gorm.DB) {
-	cameraDeviceID := uint(1)
-	prevValue := uint(33504)
-	dailyUsages := []int{5, 7, 6, 8, 6, 5, 7, 6, 8, 10, 6, 7, 8, 5, 9, 7, 8, 9, 7, 9, 8, 6, 7, 9, 7, 6, 9, 7, 9, 7}
-	year := time.Now().Year()
-	month := time.September
+	type buildingConfig struct {
+		deviceID    uint
+		startValue  int
+		dailyUsages []int // m³ consumed each day, oldest → newest
+	}
 
-	for day := 1; day <= len(dailyUsages); day++ {
-		ts := time.Date(year, month, day, 10, 0, 0, 0, time.Local)
-		dailyUsage := dailyUsages[day-1]
-		meterValue := int(prevValue) + dailyUsage
+	// 30 days of realistic daily usage per building type
+	configs := []buildingConfig{
+		{
+			deviceID: 1, startValue: 33504,
+			dailyUsages: []int{5, 7, 6, 8, 6, 5, 7, 6, 8, 10, 6, 7, 8, 5, 9, 7, 8, 9, 7, 9, 8, 6, 7, 9, 7, 6, 9, 7, 9, 7},
+		},
+		{
+			deviceID: 2, startValue: 18200, // โรงอาหาร — ใช้น้ำสูง
+			dailyUsages: []int{14, 12, 15, 13, 16, 14, 11, 15, 13, 17, 14, 12, 16, 13, 15, 14, 12, 16, 15, 13, 14, 16, 12, 15, 14, 13, 16, 14, 15, 13},
+		},
+		{
+			deviceID: 3, startValue: 8500, // ศูนย์สุขภาพช่องปาก
+			dailyUsages: []int{4, 5, 4, 6, 5, 4, 6, 5, 4, 7, 5, 4, 6, 5, 7, 5, 4, 6, 5, 6, 4, 5, 7, 5, 6, 4, 5, 6, 5, 4},
+		},
+		{
+			deviceID: 4, startValue: 12000, // ศูนย์ความเป็นเลิศทางการแพทย์
+			dailyUsages: []int{8, 9, 7, 10, 8, 9, 11, 8, 7, 10, 9, 8, 11, 9, 8, 10, 9, 7, 11, 9, 8, 10, 9, 8, 11, 8, 9, 10, 8, 9},
+		},
+		{
+			deviceID: 5, startValue: 9800, // ศูนย์รังสีวินิจฉัย
+			dailyUsages: []int{6, 7, 5, 8, 6, 7, 9, 6, 5, 8, 7, 6, 9, 7, 6, 8, 7, 5, 9, 7, 6, 8, 7, 6, 9, 6, 7, 8, 6, 7},
+		},
+		{
+			deviceID: 6, startValue: 11500, // วิเคราะห์และบำบัดโรค
+			dailyUsages: []int{9, 10, 8, 11, 9, 10, 12, 9, 8, 11, 10, 9, 12, 10, 9, 11, 10, 8, 12, 10, 9, 11, 10, 9, 12, 9, 10, 11, 9, 10},
+		},
+		{
+			deviceID: 7, startValue: 7200, // สร้างเสริมสุขภาพ
+			dailyUsages: []int{4, 5, 3, 6, 4, 5, 7, 4, 3, 6, 5, 4, 7, 5, 4, 6, 5, 3, 7, 5, 4, 6, 5, 4, 7, 4, 5, 6, 4, 5},
+		},
+		{
+			deviceID: 8, startValue: 6800, // พยาธิวิทยาโภชนาการ
+			dailyUsages: []int{3, 4, 3, 5, 4, 3, 5, 4, 3, 6, 4, 3, 5, 4, 6, 4, 3, 5, 4, 5, 3, 4, 6, 4, 5, 3, 4, 5, 4, 3},
+		},
+	}
 
-		imagePath := fmt.Sprintf("uploads/meter%d.jpg", 1)
+	now := time.Now()
+	totalDays := 30
 
-		var adminUser entity.User
-		database.First(&adminUser, "email = ?", "suth@gmail.com") // หรือ user อื่นที่มีอยู่จริง
-
-		wm := entity.WaterMeterValue{
-			MeterValue:      meterValue,
-			Timestamp:       ts,
-			ModelConfidence: 95,
-			DeviceID:        cameraDeviceID,
-			StatusID:        1,
-			ImagePath:       imagePath,
-			UserID:          1,
+	for _, cfg := range configs {
+		// idempotent — skip if device already has data
+		var count int64
+		database.Model(&entity.WaterMeterValue{}).Where("device_id = ?", cfg.deviceID).Count(&count)
+		if count > 0 {
+			continue
 		}
 
-		database.Create(&wm)
+		prevValue := cfg.startValue
+		for i, usage := range cfg.dailyUsages {
+			daysAgo := totalDays - 1 - i
+			ts := now.AddDate(0, 0, -daysAgo)
+			ts = time.Date(ts.Year(), ts.Month(), ts.Day(), 9, 30, 0, 0, time.Local)
 
-		prevValue = uint(meterValue)
+			meterValue := prevValue + usage
+			statusID := uint(2) // approved สำหรับข้อมูลย้อนหลัง
+			if daysAgo < 3 {
+				statusID = 1 // pending สำหรับ 3 วันล่าสุด
+			}
+
+			confidence := 92.0 + float64((cfg.deviceID+uint(i))%8)
+
+			wm := entity.WaterMeterValue{
+				MeterValue:      meterValue,
+				Timestamp:       ts,
+				ModelConfidence: confidence,
+				DeviceID:        cfg.deviceID,
+				StatusID:        statusID,
+				ImagePath:       fmt.Sprintf("uploads/meter%d.jpg", cfg.deviceID),
+				UserID:          1,
+			}
+			database.Create(&wm)
+			prevValue = meterValue
+		}
 	}
 }
 

--- a/backend/controller/maintainlog/maintainlog.go
+++ b/backend/controller/maintainlog/maintainlog.go
@@ -1,8 +1,11 @@
 package maintainlog
 
 import (
+	"fmt"
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -31,7 +34,8 @@ func NewMaintainLogHandler(router *gin.RouterGroup, maintainLogService services.
 	g.GET("", staffNoUser, handler.GetAll)
 	g.GET("/statuses", staffNoUser, handler.GetStatuses)
 	g.GET("/:id", staffNoUser, handler.GetByID)
-	g.POST("", handler.Create) // ทุก role ส่งปัญหาได้
+	g.POST("", handler.Create)          // ทุก role ส่งปัญหาได้ (JSON)
+	g.POST("/report", handler.CreateReport) // ทุก role ส่งพร้อมรูป (multipart)
 	g.PUT("/:id", staffNoUser, handler.Update)
 	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
@@ -80,6 +84,58 @@ func (h *MaintainLogHandler) Create(c *gin.Context) {
 	}
 
 	// ส่ง system notification ให้ผู้รายงาน (ถ้ามี userID ใน context)
+	if userID, ok := utils.GetUserIDFromContext(c); ok {
+		_ = h.notificationService.CreateSystemNotification(
+			"รายงานปัญหาของคุณถูกบันทึกแล้ว: "+log.Title, userID,
+		)
+	}
+
+	utils.JSONSuccess(c, http.StatusCreated, log)
+}
+
+// CreateReport รับ multipart/form-data พร้อม optional image
+func (h *MaintainLogHandler) CreateReport(c *gin.Context) {
+	title := c.PostForm("title")
+	locationText := c.PostForm("location_text")
+	if title == "" || locationText == "" {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidPayload)
+		return
+	}
+
+	payload := models.MaintainLogRequest{
+		Title:        title,
+		LocationText: locationText,
+	}
+
+	if raw := c.PostForm("location_id"); raw != "" {
+		if v, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			u := uint(v)
+			payload.LocationID = &u
+		}
+	}
+
+	pending := uint(1)
+	payload.StatusID = &pending
+
+	if file, header, err := c.Request.FormFile("image"); err == nil {
+		defer file.Close()
+		ext := filepath.Ext(header.Filename)
+		if ext == "" {
+			ext = ".jpg"
+		}
+		filename := fmt.Sprintf("maintain_%s%s", time.Now().Format("20060102_150405"), ext)
+		dst := filepath.Join("uploads", filename)
+		if saveErr := c.SaveUploadedFile(header, dst); saveErr == nil {
+			payload.ImagePath = "uploads/" + filename
+		}
+	}
+
+	log, err := h.maintainLogService.Create(payload)
+	if err != nil {
+		utils.NewError(c, http.StatusInternalServerError, utils.ErrCreateFailed)
+		return
+	}
+
 	if userID, ok := utils.GetUserIDFromContext(c); ok {
 		_ = h.notificationService.CreateSystemNotification(
 			"รายงานปัญหาของคุณถูกบันทึกแล้ว: "+log.Title, userID,

--- a/backend/controller/users/user_controller.go
+++ b/backend/controller/users/user_controller.go
@@ -145,6 +145,12 @@ func (h *UserHandler) AdminDeleteUser(c *gin.Context) {
 		return
 	}
 
+	targetUser, err := h.userService.GetProfile(uint(targetID))
+	if err == nil && targetUser != nil && targetUser.RoleID == 1 {
+		utils.JSONError(c, http.StatusForbidden, "ไม่สามารถลบผู้ใช้ที่มีบทบาทผู้ดูแลได้", "")
+		return
+	}
+
 	if err := h.userService.DeleteUser(uint(targetID)); err != nil {
 		if err.Error() == "user not found" {
 			utils.NewError(c, http.StatusNotFound, utils.ErrNotFound)

--- a/backend/controller/waterlog/waterlog.go
+++ b/backend/controller/waterlog/waterlog.go
@@ -1,8 +1,11 @@
 package waterlog
 
 import (
+	"fmt"
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -32,16 +35,19 @@ func NewWaterLogHandler(router *gin.RouterGroup, waterService services.WaterMete
 	g.GET("/statuses", staffOnly, handler.GetStatuses)
 	g.GET("/:id", staffOnly, handler.GetByID)
 	g.POST("", adminOrEngineer, handler.Create)
+	g.POST("/manual", adminOrEngineer, handler.CreateManual)
 	g.PUT("/:id", adminOrEngineer, handler.Update)
 	g.DELETE("/:id", adminOrEngineer, handler.Delete)
 
 	return handler
 }
 
-// GetAll รองรับ query params: ?device_id=X&status_id=Y
+// GetAll รองรับ query params: ?device_id=X&status_id=Y&start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
 func (h *WaterLogHandler) GetAll(c *gin.Context) {
 	var deviceID *uint
 	var statusID *uint
+	var startDate *time.Time
+	var endDate *time.Time
 
 	if raw := c.Query("device_id"); raw != "" {
 		if v, err := strconv.ParseUint(raw, 10, 64); err == nil {
@@ -55,8 +61,19 @@ func (h *WaterLogHandler) GetAll(c *gin.Context) {
 			statusID = &u
 		}
 	}
+	if raw := c.Query("start_date"); raw != "" {
+		if t, err := time.ParseInLocation("2006-01-02", raw, time.Local); err == nil {
+			startDate = &t
+		}
+	}
+	if raw := c.Query("end_date"); raw != "" {
+		if t, err := time.ParseInLocation("2006-01-02", raw, time.Local); err == nil {
+			end := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.Local)
+			endDate = &end
+		}
+	}
 
-	values, err := h.waterService.GetAll(deviceID, statusID)
+	values, err := h.waterService.GetAll(deviceID, statusID, startDate, endDate)
 	if err != nil {
 		utils.NewError(c, http.StatusInternalServerError, utils.ErrInternalServer)
 		return
@@ -120,6 +137,67 @@ func (h *WaterLogHandler) Create(c *gin.Context) {
 		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidPayload)
 		return
 	}
+	if err := h.validate.Struct(payload); err != nil {
+		utils.JSONError(c, http.StatusBadRequest, utils.ErrValidation.Error(), err.Error())
+		return
+	}
+
+	value, err := h.waterService.Create(payload, userID)
+	if err != nil {
+		utils.NewError(c, http.StatusInternalServerError, utils.ErrCreateFailed)
+		return
+	}
+	utils.JSONSuccess(c, http.StatusCreated, value)
+}
+
+// CreateManual รับ multipart/form-data พร้อม optional image file
+func (h *WaterLogHandler) CreateManual(c *gin.Context) {
+	userID, exists := utils.GetUserIDFromContext(c)
+	if !exists {
+		utils.NewError(c, http.StatusUnauthorized, utils.ErrMissingID)
+		return
+	}
+
+	meterValueStr := c.PostForm("meter_value")
+	meterValue, err := strconv.Atoi(meterValueStr)
+	if err != nil {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidPayload)
+		return
+	}
+
+	deviceIDStr := c.PostForm("device_id")
+	deviceID64, err := strconv.ParseUint(deviceIDStr, 10, 64)
+	if err != nil {
+		utils.NewError(c, http.StatusBadRequest, utils.ErrInvalidPayload)
+		return
+	}
+
+	payload := models.WaterMeterValueRequest{
+		MeterValue: meterValue,
+		DeviceID:   uint(deviceID64),
+		Note:       c.PostForm("note"),
+		StatusID:   2, // manual entry → approve ทันที
+	}
+
+	if tsStr := c.PostForm("timestamp"); tsStr != "" {
+		if t, err := time.Parse(time.RFC3339, tsStr); err == nil {
+			payload.Timestamp = &t
+		}
+	}
+
+	if file, header, ferr := c.Request.FormFile("image"); ferr == nil {
+		defer file.Close()
+		ext := filepath.Ext(header.Filename)
+		if ext == "" {
+			ext = ".jpg"
+		}
+		filename := fmt.Sprintf("manual_%d_%s%s", userID, time.Now().Format("20060102_150405"), ext)
+		dst := filepath.Join("uploads", filename)
+		if saveErr := c.SaveUploadedFile(header, dst); saveErr == nil {
+			payload.ImagePath = "uploads/" + filename
+		}
+	}
+
 	if err := h.validate.Struct(payload); err != nil {
 		utils.JSONError(c, http.StatusBadRequest, utils.ErrValidation.Error(), err.Error())
 		return

--- a/backend/controller/waterlog/waterlog_test.go
+++ b/backend/controller/waterlog/waterlog_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/watermeter/suth/config/models"
@@ -14,18 +15,18 @@ import (
 )
 
 type mockWaterService struct {
-	getAllFn            func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error)
-	getByIDFn          func(id uint) (*models.WaterMeterValueResponse, error)
-	getLatestFn        func() ([]models.WaterMeterValueResponse, error)
-	getPendingFn       func() ([]models.WaterMeterValueResponse, error)
-	getStatusesFn      func() ([]models.StatusValueResponse, error)
-	createFn           func(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error)
-	updateFn           func(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error)
-	deleteFn           func(id uint) error
+	getAllFn       func(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error)
+	getByIDFn     func(id uint) (*models.WaterMeterValueResponse, error)
+	getLatestFn   func() ([]models.WaterMeterValueResponse, error)
+	getPendingFn  func() ([]models.WaterMeterValueResponse, error)
+	getStatusesFn func() ([]models.StatusValueResponse, error)
+	createFn      func(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error)
+	updateFn      func(id uint, input models.UpdateWaterMeterValueRequest) (*models.WaterMeterValueResponse, error)
+	deleteFn      func(id uint) error
 }
 
-func (m *mockWaterService) GetAll(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
-	return m.getAllFn(deviceID, statusID)
+func (m *mockWaterService) GetAll(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error) {
+	return m.getAllFn(deviceID, statusID, startDate, endDate)
 }
 func (m *mockWaterService) GetByID(id uint) (*models.WaterMeterValueResponse, error) {
 	return m.getByIDFn(id)
@@ -95,7 +96,7 @@ var sampleValue = models.WaterMeterValueResponse{ID: 1, MeterValue: 100, DeviceI
 
 func TestGetAll_NoParams(t *testing.T) {
 	r := setupRouter(&mockWaterService{
-		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+		getAllFn: func(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error) {
 			if deviceID != nil || statusID != nil {
 				t.Error("expected nil params")
 			}
@@ -109,7 +110,7 @@ func TestGetAll_NoParams(t *testing.T) {
 
 func TestGetAll_WithQueryParams(t *testing.T) {
 	r := setupRouter(&mockWaterService{
-		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+		getAllFn: func(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error) {
 			if deviceID == nil || *deviceID != 2 {
 				t.Errorf("expected deviceID=2, got %v", deviceID)
 			}
@@ -126,7 +127,7 @@ func TestGetAll_WithQueryParams(t *testing.T) {
 
 func TestGetAll_ServiceError(t *testing.T) {
 	r := setupRouter(&mockWaterService{
-		getAllFn: func(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
+		getAllFn: func(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error) {
 			return nil, errors.New("db error")
 		},
 	}, nil)

--- a/backend/entity/maintain_log.go
+++ b/backend/entity/maintain_log.go
@@ -11,6 +11,7 @@ type MaintainLog struct {
 	Title        string    `json:"title"`
 	LocationText string    `json:"location_text"`
 	CloseAt      time.Time `json:"close_at"`
+	ImagePath    string    `json:"image_path"`
 
 	LocationID *uint      `json:"location_id"`
 	Location   *Location `gorm:"foreignKey:LocationID" json:"location,omitempty"`

--- a/backend/repositories/maintain_log_repository.go
+++ b/backend/repositories/maintain_log_repository.go
@@ -51,7 +51,7 @@ func (r *maintainLogRepository) FindByID(id uint) (*entity.MaintainLog, error) {
 }
 
 func (r *maintainLogRepository) Update(log *entity.MaintainLog) error {
-	return r.db.Save(log).Error
+	return r.db.Omit("Status", "Location").Save(log).Error
 }
 
 func (r *maintainLogRepository) Delete(log *entity.MaintainLog) error {

--- a/backend/repositories/water_meter_value_repository.go
+++ b/backend/repositories/water_meter_value_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"errors"
+	"time"
 
 	"github.com/watermeter/suth/entity"
 	"gorm.io/gorm"
@@ -9,7 +10,7 @@ import (
 
 type WaterMeterValueRepository interface {
 	Create(value *entity.WaterMeterValue) error
-	FetchAll(deviceID *uint, statusID *uint) ([]entity.WaterMeterValue, error)
+	FetchAll(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]entity.WaterMeterValue, error)
 	FindByID(id uint) (*entity.WaterMeterValue, error)
 	FetchLatestPerDevice() ([]entity.WaterMeterValue, error)
 	Update(value *entity.WaterMeterValue) error
@@ -29,7 +30,7 @@ func (r *waterMeterValueRepository) Create(value *entity.WaterMeterValue) error 
 	return r.db.Create(value).Error
 }
 
-func (r *waterMeterValueRepository) FetchAll(deviceID *uint, statusID *uint) ([]entity.WaterMeterValue, error) {
+func (r *waterMeterValueRepository) FetchAll(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]entity.WaterMeterValue, error) {
 	query := r.db.
 		Preload("Device").
 		Preload("Device.Location").
@@ -42,6 +43,12 @@ func (r *waterMeterValueRepository) FetchAll(deviceID *uint, statusID *uint) ([]
 	}
 	if statusID != nil {
 		query = query.Where("status_id = ?", *statusID)
+	}
+	if startDate != nil {
+		query = query.Where("timestamp >= ?", *startDate)
+	}
+	if endDate != nil {
+		query = query.Where("timestamp <= ?", *endDate)
 	}
 
 	var values []entity.WaterMeterValue

--- a/backend/services/maintain_log.go
+++ b/backend/services/maintain_log.go
@@ -56,6 +56,7 @@ func (s *maintainLogService) Create(input models.MaintainLogRequest) (*models.Ma
 		LocationText: input.LocationText,
 		LocationID:   input.LocationID,
 		StatusID:     input.StatusID,
+		ImagePath:    input.ImagePath,
 	}
 	if input.CloseAt != nil {
 		log.CloseAt = *input.CloseAt
@@ -80,6 +81,9 @@ func (s *maintainLogService) Update(id uint, input models.UpdateMaintainLogReque
 	}
 	if log == nil {
 		return nil, errors.New("maintain log not found")
+	}
+	if log.Status != nil && log.Status.StatusLog == "solved" {
+		return nil, errors.New("ไม่สามารถแก้ไขบันทึกที่เสร็จสิ้นแล้ว")
 	}
 
 	if input.Title != "" {
@@ -143,6 +147,7 @@ func mapMaintainLogToResponse(log *entity.MaintainLog) models.MaintainLogRespons
 		ID:           log.ID,
 		Title:        log.Title,
 		LocationText: log.LocationText,
+		ImagePath:    log.ImagePath,
 		LocationID:   log.LocationID,
 		StatusID:     log.StatusID,
 		CreatedAt:    log.CreatedAt.Format(time.RFC3339),

--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -92,6 +92,9 @@ func (s *userService) UpdateRoleAndPosition(targetUserID uint, input models.Upda
 	if user == nil {
 		return nil, errors.New("user not found")
 	}
+	if user.RoleID == 1 {
+		return nil, errors.New("ไม่สามารถแก้ไขผู้ใช้ที่มีบทบาทผู้ดูแลได้")
+	}
 
 	user.RoleID = input.RoleID
 	user.PositionID = input.PositionID

--- a/backend/services/water_meter_value.go
+++ b/backend/services/water_meter_value.go
@@ -9,10 +9,13 @@ import (
 	"github.com/watermeter/suth/repositories"
 )
 
-const statusPending = uint(1)
+const (
+	statusPending  = uint(1)
+	statusApproved = uint(2)
+)
 
 type WaterMeterValueService interface {
-	GetAll(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error)
+	GetAll(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error)
 	GetByID(id uint) (*models.WaterMeterValueResponse, error)
 	GetLatestPerDevice() ([]models.WaterMeterValueResponse, error)
 	GetPending() ([]models.WaterMeterValueResponse, error)
@@ -30,8 +33,8 @@ func NewWaterMeterValueService(repo repositories.WaterMeterValueRepository) Wate
 	return &waterMeterValueService{repo: repo}
 }
 
-func (s *waterMeterValueService) GetAll(deviceID *uint, statusID *uint) ([]models.WaterMeterValueResponse, error) {
-	values, err := s.repo.FetchAll(deviceID, statusID)
+func (s *waterMeterValueService) GetAll(deviceID *uint, statusID *uint, startDate *time.Time, endDate *time.Time) ([]models.WaterMeterValueResponse, error) {
+	values, err := s.repo.FetchAll(deviceID, statusID, startDate, endDate)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +70,18 @@ func (s *waterMeterValueService) GetLatestPerDevice() ([]models.WaterMeterValueR
 }
 
 func (s *waterMeterValueService) GetPending() ([]models.WaterMeterValueResponse, error) {
-	return s.GetAll(nil, &[]uint{statusPending}[0])
+	return s.GetAll(nil, &[]uint{statusPending}[0], nil, nil)
 }
 
 func (s *waterMeterValueService) Create(input models.WaterMeterValueRequest, userID uint) (*models.WaterMeterValueResponse, error) {
 	ts := time.Now()
 	if input.Timestamp != nil {
 		ts = *input.Timestamp
+	}
+
+	sid := statusPending
+	if input.StatusID != 0 {
+		sid = input.StatusID
 	}
 
 	value := &entity.WaterMeterValue{
@@ -84,7 +92,7 @@ func (s *waterMeterValueService) Create(input models.WaterMeterValueRequest, use
 		ImagePath:       input.ImagePath,
 		DeviceID:        input.DeviceID,
 		UserID:          userID,
-		StatusID:        statusPending,
+		StatusID:        sid,
 	}
 
 	if err := s.repo.Create(value); err != nil {

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -1,15 +1,13 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { message } from "antd";
 import { UsersInterface } from "../interfaces/IUser";
 import { GetUsersById } from "../services/https/user";
 import { GetAllNotifications } from "../services/https/message";
 import { GetMerters } from "../services/https/meter";
-import { GetAllWaterDaily, GetAllWaterUsageLogs} from "../services/https/waterValue";
+import { GetAllWaterUsageLogs } from "../services/https/waterValue";
 import {
   MeterLocationInterface,
-  WaterMeterValueInterface,
   NotificationInterface,
-  CameraDeviceInterface,
+  WaterValueResponse,
 } from "../interfaces/InterfaceAll";
 import { AppContext } from "./AppContextDef";
 
@@ -18,14 +16,12 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const id = String(localStorage.getItem("id") ?? "");
   const token = localStorage.getItem("token");
-  const [messageApi] = message.useMessage();
   const [user, setUser] = useState<UsersInterface | null>(null);
   const [meters, setMeters] = useState<MeterLocationInterface[]>([]);
-  const [waterusage, setWaterUsage] = useState<WaterMeterValueInterface[]>([]);
-  const [waterDaily, setWaterDaily] = useState<CameraDeviceInterface[]>([]);
+  const [waterusage, setWaterUsage] = useState<WaterValueResponse[]>([]);
   const [notifications, setNotifications] = useState<NotificationInterface[]>([]);
   const [loading, setLoading] = useState(true);
-  
+
   const getUserById = useCallback(async () => {
     if (!id || !token) return;
     try {
@@ -34,14 +30,11 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setUser({ ...res.data });
       } else {
         setUser(null);
-        messageApi.error(res?.data?.error || "ไม่สามารถโหลดข้อมูลผู้ใช้ได้");
       }
-    } catch (error) {
-      console.error("Error fetching user data:", error);
+    } catch {
       setUser(null);
-      messageApi.error("เกิดข้อผิดพลาดในการเชื่อมต่อกับเซิร์ฟเวอร์");
     }
-  }, [id, token, messageApi]);
+  }, [id, token]);
 
   const getMeters = useCallback(async () => {
     if (!token) return;
@@ -52,14 +45,11 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setMeters(Array.isArray(data) ? data : []);
       } else {
         setMeters([]);
-        messageApi.error(res?.data?.error || "ไม่สามารถโหลดข้อมูลมิเตอร์ได้");
       }
-    } catch (error) {
-      console.error("Error fetching meter data:", error);
+    } catch {
       setMeters([]);
-      messageApi.error("เกิดข้อผิดพลาดในการโหลดมิเตอร์");
     }
-  }, [token, messageApi]);
+  }, [token]);
 
   const getNotification = useCallback(async () => {
     if (!token) return;
@@ -70,62 +60,35 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         setNotifications(Array.isArray(data) ? data : []);
       } else {
         setNotifications([]);
-        messageApi.error(res?.data?.error || "ไม่สามารถโหลดการแจ้งเตือนได้");
       }
-    } catch (error) {
-      console.error("Error fetching notifications:", error);
+    } catch {
       setNotifications([]);
-      messageApi.error("เกิดข้อผิดพลาดในการโหลดการแจ้งเตือน");
     }
-  }, [token, messageApi]);
+  }, [token]);
 
   const getWaterLog = useCallback(async () => {
     if (!token) return;
     try {
       const res = await GetAllWaterUsageLogs();
       if (res && res.status === 200) {
-        setWaterUsage(res.data);
+        const data = res.data?.data ?? res.data;
+        setWaterUsage(Array.isArray(data) ? data : []);
       } else {
         setWaterUsage([]);
-        messageApi.error(res?.data?.error || "ไม่สามารถโหลดข้อมูลการใช้น้ำได้");
       }
-    } catch (error) {
-      console.error("Error fetching water usage logs:", error);
+    } catch {
       setWaterUsage([]);
-      messageApi.error("เกิดข้อผิดพลาดในการโหลดข้อมูลการใช้น้ำ");
     }
-  }, [token, messageApi]);
-
-  const getAllWaterDaily = useCallback(async () => {
-    try {
-      const res = await GetAllWaterDaily();
-      if (res.status === 200) {
-        setWaterDaily(res.data);
-      } else {
-        setWaterDaily([]);
-        messageApi.error(res.data.error);
-      }
-    } catch (error) {
-      console.error("Error fetching daily water data:", error);
-      setWaterDaily([]);
-    }
-  }, [messageApi]);
+  }, [token]);
 
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      await Promise.all([
-        getUserById(),
-        getMeters(),
-        getWaterLog(),
-        getNotification(),
-        getAllWaterDaily()
-      ]);
+      await Promise.all([getUserById(), getMeters(), getWaterLog(), getNotification()]);
       setLoading(false);
     };
-
     fetchData();
-  }, [getUserById, getMeters, getWaterLog, getNotification, getAllWaterDaily]); // ใส่ dependencies ให้ครบ
+  }, [getUserById, getMeters, getWaterLog, getNotification]);
 
   return (
     <AppContext.Provider
@@ -138,7 +101,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
         loading,
         setLoading,
         waterusage,
-        waterDaily,
         notifications,
       }}
     >

--- a/frontend/src/contexts/AppContextDef.ts
+++ b/frontend/src/contexts/AppContextDef.ts
@@ -2,9 +2,8 @@ import { createContext, useContext } from "react";
 import type { UsersInterface } from "../interfaces/IUser";
 import type {
   MeterLocationInterface,
-  WaterMeterValueInterface,
   NotificationInterface,
-  CameraDeviceInterface,
+  WaterValueResponse,
 } from "../interfaces/InterfaceAll";
 
 export type AppContextType = {
@@ -15,8 +14,7 @@ export type AppContextType = {
   getNotification: () => Promise<void>;
   loading: boolean;
   setLoading: (loading: boolean) => void;
-  waterusage: WaterMeterValueInterface[];
-  waterDaily: CameraDeviceInterface[];
+  waterusage: WaterValueResponse[];
   notifications: NotificationInterface[];
 };
 
@@ -29,7 +27,6 @@ export const AppContext = createContext<AppContextType>({
   loading: true,
   setLoading: () => {},
   waterusage: [],
-  waterDaily: [],
   notifications: [],
 });
 

--- a/frontend/src/interfaces/InterfaceAll.ts
+++ b/frontend/src/interfaces/InterfaceAll.ts
@@ -22,6 +22,7 @@ export interface MaintainLogInterface {
   title: string;
   location_text: string;
   close_at?: string;
+  image_path?: string;
   location_id?: number | null;
   location?: MeterLocationInterface;
   status_id?: number | null;
@@ -161,3 +162,21 @@ export interface DashboardStats {
 }
 
 export type StatusType = "รอการอนุมัติ" | "อนุมัติ";
+
+// Shape matching GET /water-values response (new backend)
+export interface WaterValueResponse {
+  id: number;
+  meter_value: number;
+  timestamp: string;
+  model_confidence: number;
+  note: string;
+  image_path: string;
+  device_id: number;
+  device?: { id: number; mac_address: string; location_id: number | null };
+  user_id: number;
+  user?: { id: number; first_name: string; last_name: string };
+  status_id: number;
+  status?: { id: number; status_value: string; description: string };
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/pages/maintain/MaintainLogPage.tsx
+++ b/frontend/src/pages/maintain/MaintainLogPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
-import { message } from "antd";
-import { Search, Plus, Pencil, Trash2, X, Wrench, Save, MapPin, Calendar } from "lucide-react";
+import { message, Image } from "antd";
+import { Search, Plus, Pencil, Trash2, X, Wrench, Save, MapPin, Calendar, Lock } from "lucide-react";
 import dayjs from "dayjs";
+
+const apiBase = import.meta.env.VITE_API_BASE_URL as string;
 import { MaintainLogInterface, StatusLogInterface, MeterLocationInterface } from "../../interfaces/InterfaceAll";
 import {
   GetMaintainLogs,
@@ -19,6 +21,10 @@ const TEXTAREA =
 const SELECT =
   "w-full h-10 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20";
 const LABEL = "block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1";
+
+function isSolved(log: MaintainLogInterface) {
+  return log.status?.status_log === "solved";
+}
 
 // Color coding by keyword in status name
 function statusColor(s?: StatusLogInterface) {
@@ -289,21 +295,38 @@ export default function MainTainPage() {
                         </div>
                       )}
                     </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      <button
-                        onClick={() => openEdit(l)}
-                        className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
-                      >
-                        <Pencil size={14} />
-                      </button>
-                      {canDelete && (
-                        <button
-                          onClick={() => setDeleteTarget(l)}
-                          className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-0 bg-transparent cursor-pointer"
-                        >
-                          <Trash2 size={14} />
-                        </button>
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      {l.image_path && (
+                        <Image
+                          src={`${apiBase}/${l.image_path}`}
+                          width={56}
+                          height={56}
+                          className="!rounded-lg object-cover cursor-pointer"
+                          preview={{ mask: false }}
+                        />
                       )}
+                      <div className="flex items-center gap-1">
+                        {isSolved(l) ? (
+                          <span className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-300 dark:text-gray-600" title="เสร็จสิ้นแล้ว ไม่สามารถแก้ไขได้">
+                            <Lock size={14} />
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => openEdit(l)}
+                            className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                          >
+                            <Pencil size={14} />
+                          </button>
+                        )}
+                        {canDelete && (
+                          <button
+                            onClick={() => setDeleteTarget(l)}
+                            className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        )}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -316,7 +339,7 @@ export default function MainTainPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-gray-100 dark:border-gray-800">
-                      {["#", "หัวข้อ", "สถานที่", "สถานะ", "กำหนดปิด", "วันที่แจ้ง", ""].map((h, i) => (
+                      {["#", "รูป", "หัวข้อ", "สถานที่", "สถานะ", "กำหนดปิด", "วันที่แจ้ง", ""].map((h, i) => (
                         <th
                           key={i}
                           className={`px-5 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide ${i < 6 ? "text-left" : ""}`}
@@ -330,6 +353,19 @@ export default function MainTainPage() {
                     {filtered.map((l, idx) => (
                       <tr key={l.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
                         <td className="px-5 py-3.5 text-gray-400 dark:text-gray-500 text-xs">{idx + 1}</td>
+                        <td className="px-4 py-3.5">
+                          {l.image_path ? (
+                            <Image
+                              src={`${apiBase}/${l.image_path}`}
+                              width={48}
+                              height={48}
+                              className="!rounded-lg object-cover cursor-pointer"
+                              preview={{ mask: false }}
+                            />
+                          ) : (
+                            <span className="text-gray-300 dark:text-gray-700 text-xs">—</span>
+                          )}
+                        </td>
                         <td className="px-5 py-3.5 max-w-[200px]">
                           <p className="font-medium text-gray-900 dark:text-gray-100 truncate">{l.title}</p>
                         </td>
@@ -361,12 +397,18 @@ export default function MainTainPage() {
                         </td>
                         <td className="px-5 py-3.5">
                           <div className="flex items-center justify-end gap-1">
-                            <button
-                              onClick={() => openEdit(l)}
-                              className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
-                            >
-                              <Pencil size={14} />
-                            </button>
+                            {isSolved(l) ? (
+                              <span className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-300 dark:text-gray-600" title="เสร็จสิ้นแล้ว ไม่สามารถแก้ไขได้">
+                                <Lock size={14} />
+                              </span>
+                            ) : (
+                              <button
+                                onClick={() => openEdit(l)}
+                                className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                              >
+                                <Pencil size={14} />
+                              </button>
+                            )}
                             {canDelete && (
                               <button
                                 onClick={() => setDeleteTarget(l)}

--- a/frontend/src/pages/maintain/NotiMaintainPage.tsx
+++ b/frontend/src/pages/maintain/NotiMaintainPage.tsx
@@ -1,10 +1,308 @@
-function NotiMainTainPage() { 
+import { useEffect, useState } from "react";
+import {
+  Wrench, MapPin, CheckCircle2, ChevronRight,
+  AlertTriangle, Droplets, Gauge, Eye, ThumbsUp, RotateCcw, ImagePlus, X,
+} from "lucide-react";
+import { useAppContext } from "../../contexts/AppContextDef";
+import { CreateMaintainLogReport } from "../../services/https/maintain";
 
+// ——— ปัญหาที่พบบ่อย ———
+const PRESETS = [
+  { label: "น้ำรั่ว",                 icon: Droplets,      color: "text-blue-500",   bg: "bg-blue-50 dark:bg-blue-900/20",   border: "border-blue-200 dark:border-blue-800" },
+  { label: "ท่อแตก",                  icon: AlertTriangle, color: "text-red-500",    bg: "bg-red-50 dark:bg-red-900/20",     border: "border-red-200 dark:border-red-800" },
+  { label: "มิเตอร์ไม่ทำงาน",         icon: Gauge,         color: "text-orange-500", bg: "bg-orange-50 dark:bg-orange-900/20", border: "border-orange-200 dark:border-orange-800" },
+  { label: "ต้องตรวจสอบด้วยมือ",      icon: Eye,           color: "text-purple-500", bg: "bg-purple-50 dark:bg-purple-900/20", border: "border-purple-200 dark:border-purple-800" },
+  { label: "ค่ามิเตอร์สูงผิดปกติ",    icon: Gauge,         color: "text-amber-500",  bg: "bg-amber-50 dark:bg-amber-900/20", border: "border-amber-200 dark:border-amber-800" },
+  { label: "ค่ามิเตอร์ต่ำผิดปกติ",    icon: Gauge,         color: "text-teal-500",   bg: "bg-teal-50 dark:bg-teal-900/20",   border: "border-teal-200 dark:border-teal-800" },
+  { label: "อื่นๆ",                   icon: Wrench,        color: "text-gray-500",   bg: "bg-gray-50 dark:bg-gray-800",      border: "border-gray-200 dark:border-gray-700" },
+];
+
+const INPUT =
+  "w-full px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-xl outline-none transition-all focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 placeholder:text-gray-400";
+
+type Submitted = { title: string; location_text: string; building?: string; time: string };
+
+export default function NotiMaintainPage() {
+  const { meters } = useAppContext();
+
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  const [title, setTitle]       = useState("");
+  const [locationText, setLocationText] = useState("");
+  const [locationId, setLocationId]     = useState<number | "">("");
+  const [imageFile, setImageFile]       = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [submitting, setSubmitting]     = useState(false);
+  const [submitted, setSubmitted]       = useState<Submitted | null>(null);
+  const [error, setError]               = useState("");
+
+  // ซิงค์ title เมื่อเลือก preset
+  useEffect(() => {
+    if (selectedPreset && selectedPreset !== "อื่นๆ") setTitle(selectedPreset);
+    if (selectedPreset === "อื่นๆ") setTitle("");
+  }, [selectedPreset]);
+
+  const isValid = title.trim() !== "" && locationText.trim() !== "";
+
+  const handlePreset = (label: string) => {
+    setSelectedPreset((prev) => (prev === label ? null : label));
+    setError("");
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setImageFile(file);
+    setImagePreview(file ? URL.createObjectURL(file) : null);
+  };
+
+  const clearImage = () => {
+    setImageFile(null);
+    setImagePreview(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!isValid) { setError("กรุณากรอกหัวข้อและรายละเอียดสถานที่"); return; }
+    setSubmitting(true);
+    setError("");
+    const building = locationId !== ""
+      ? meters.find((m) => m.id === locationId)?.building_name
+      : undefined;
+    const res = await CreateMaintainLogReport({
+      title: title.trim(),
+      location_text: locationText.trim(),
+      location_id: locationId !== "" ? locationId : null,
+      image: imageFile ?? undefined,
+    });
+    setSubmitting(false);
+    if (res?.status === 200 || res?.status === 201) {
+      setSubmitted({
+        title: title.trim(),
+        location_text: locationText.trim(),
+        building,
+        time: new Date().toLocaleString("th-TH", { dateStyle: "short", timeStyle: "short" }),
+      });
+    } else {
+      setError(res?.data?.error?.message ?? "เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง");
+    }
+  };
+
+  const handleReset = () => {
+    setSubmitted(null);
+    setSelectedPreset(null);
+    setTitle("");
+    setLocationText("");
+    setLocationId("");
+    setImageFile(null);
+    setImagePreview(null);
+    setError("");
+  };
+
+  // ——— Success screen ———
+  if (submitted) {
     return (
-        <div className="text-xl text-red-600">
-             NotiMainTain Page
-        </div>
-    )
-}
+      <div className="min-h-full bg-gray-50 dark:bg-gray-950 flex items-start justify-center p-4 sm:p-6">
+        <div className="w-full max-w-md mt-8">
+          <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-sm border border-gray-100 dark:border-gray-700 p-8 text-center">
+            <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mx-auto mb-5">
+              <CheckCircle2 size={32} className="text-green-500" />
+            </div>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">ส่งรายงานสำเร็จ</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+              ทีมงานจะรับทราบและดำเนินการโดยเร็วที่สุด
+            </p>
 
-export default NotiMainTainPage;
+            {/* Summary */}
+            <div className="bg-gray-50 dark:bg-gray-700/40 rounded-2xl p-4 text-left space-y-3 mb-6">
+              <div className="flex items-start gap-3">
+                <Wrench size={14} className="text-teal-500 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">หัวข้อปัญหา</p>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">{submitted.title}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <MapPin size={14} className="text-teal-500 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">สถานที่</p>
+                  <p className="text-sm text-gray-700 dark:text-gray-300">{submitted.location_text}</p>
+                  {submitted.building && (
+                    <p className="text-xs text-teal-600 dark:text-teal-400 mt-0.5">{submitted.building}</p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <ThumbsUp size={14} className="text-teal-500 shrink-0" />
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">เวลาแจ้ง</p>
+                  <p className="text-xs text-gray-600 dark:text-gray-400">{submitted.time}</p>
+                </div>
+              </div>
+            </div>
+
+            <button
+              onClick={handleReset}
+              className="w-full flex items-center justify-center gap-2 py-3 rounded-2xl text-sm font-semibold text-white bg-teal-600 hover:bg-teal-700 transition-colors border-0 cursor-pointer"
+            >
+              <RotateCcw size={15} />
+              แจ้งปัญหาใหม่
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ——— Form screen ———
+  return (
+    <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-4 sm:p-6">
+      <div className="w-full max-w-lg mx-auto space-y-5">
+
+        {/* ——— Header ——— */}
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-2xl bg-teal-500/10 flex items-center justify-center shrink-0">
+            <Wrench size={20} className="text-teal-600" />
+          </div>
+          <div>
+            <h1 className="text-base font-bold text-gray-900 dark:text-white">แจ้งปัญหาระบบน้ำ</h1>
+            <p className="text-xs text-gray-500 dark:text-gray-400">รายงานปัญหาที่พบเพื่อให้ทีมช่างดำเนินการ</p>
+          </div>
+        </div>
+
+        {/* ——— Quick select ——— */}
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+            เลือกประเภทปัญหา
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {PRESETS.map(({ label, icon: Icon, color, bg, border }) => {
+              const active = selectedPreset === label;
+              return (
+                <button
+                  key={label}
+                  onClick={() => handlePreset(label)}
+                  className={`flex items-center gap-2.5 px-3 py-3 rounded-xl border text-sm font-medium transition-all text-left cursor-pointer ${
+                    active
+                      ? `${bg} ${border} ${color} ring-2 ring-offset-1 ring-teal-400`
+                      : "bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-teal-300 dark:hover:border-teal-700"
+                  }`}
+                >
+                  <Icon size={16} className={active ? color : "text-gray-400"} />
+                  <span className="leading-tight">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ——— Form ——— */}
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm border border-gray-100 dark:border-gray-700 space-y-4">
+          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            รายละเอียดปัญหา
+          </p>
+
+          {/* Title */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+              หัวข้อปัญหา <span className="text-red-400">*</span>
+            </label>
+            <input
+              className={INPUT}
+              placeholder="เช่น น้ำรั่วบริเวณชั้น 2, มิเตอร์อ่านค่าผิดปกติ"
+              value={title}
+              onChange={(e) => { setTitle(e.target.value); setError(""); }}
+            />
+          </div>
+
+          {/* Location text */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+              รายละเอียดสถานที่ <span className="text-red-400">*</span>
+            </label>
+            <textarea
+              className={`${INPUT} resize-none`}
+              rows={3}
+              placeholder="ระบุตำแหน่งที่พบปัญหาให้ชัดเจน เช่น ชั้น 3 ห้องน้ำชาย ใกล้ลิฟต์ A"
+              value={locationText}
+              onChange={(e) => { setLocationText(e.target.value); setError(""); }}
+            />
+          </div>
+
+          {/* Meter location (optional) */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+              อาคาร / จุดมิเตอร์ <span className="text-xs font-normal text-gray-400">(ถ้าทราบ)</span>
+            </label>
+            <div className="relative">
+              <MapPin size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+              <select
+                className={`${INPUT} pl-8`}
+                value={locationId}
+                onChange={(e) => setLocationId(e.target.value !== "" ? Number(e.target.value) : "")}
+              >
+                <option value="">-- ไม่ทราบ / ไม่ระบุ --</option>
+                {meters.map((m) => (
+                  <option key={m.id} value={m.id}>{m.building_name}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Image upload */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+              รูปภาพประกอบ <span className="text-xs font-normal text-gray-400">(ถ้ามี)</span>
+            </label>
+            {imagePreview ? (
+              <div className="relative w-full rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+                <img src={imagePreview} alt="preview" className="w-full max-h-48 object-cover" />
+                <button
+                  onClick={clearImage}
+                  className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 flex items-center justify-center text-white hover:bg-black/70 transition-colors border-0 cursor-pointer"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ) : (
+              <label className="flex flex-col items-center justify-center gap-2 w-full h-28 rounded-xl border-2 border-dashed border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 cursor-pointer hover:border-teal-400 dark:hover:border-teal-600 transition-colors">
+                <ImagePlus size={22} className="text-gray-400" />
+                <span className="text-xs text-gray-400">คลิกเพื่อเลือกรูปภาพ</span>
+                <span className="text-xs text-gray-300 dark:text-gray-600">JPG, PNG, WEBP</span>
+                <input type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
+              </label>
+            )}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2.5">
+              <AlertTriangle size={14} className="shrink-0" />
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* ——— Submit ——— */}
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !isValid}
+          className="w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl text-sm font-bold text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors border-0 cursor-pointer shadow-sm"
+        >
+          {submitting ? (
+            <span className="flex items-center gap-2">
+              <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+              กำลังส่ง...
+            </span>
+          ) : (
+            <>
+              ส่งรายงานปัญหา
+              <ChevronRight size={16} />
+            </>
+          )}
+        </button>
+
+        <p className="text-center text-xs text-gray-400 pb-4">
+          รายงานจะถูกส่งถึงทีมวิศวกรและช่างเทคนิคทันที
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/meter/MeterMap.tsx
+++ b/frontend/src/pages/meter/MeterMap.tsx
@@ -3,12 +3,19 @@ import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import { MapContainer, TileLayer, Marker, Popup, Polygon, Tooltip, useMap } from "react-leaflet";
 import { useNavigate } from "react-router-dom";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
+import { DatePicker, Form, InputNumber, Input, Modal, message, Upload } from "antd";
+import type { UploadFile } from "antd";
+import { Plus, ImagePlus } from "lucide-react";
 import { useAppContext } from "../../contexts/AppContextDef";
-import { GetMeterLocationDetail } from "../../services/https/waterValue";
-import { DailyWaterUsageInterface } from "../../interfaces/InterfaceAll";
+import { GetDevices } from "../../services/https/device";
+import { GetWaterValues, CreateWaterValueManual } from "../../services/https/waterValue";
 
-// Teal SVG pin
+// ——— Types ———
+interface DeviceItem { id: number; mac_address: string; location_id: number | null }
+interface WaterItem  { id: number; meter_value: number; timestamp: string }
+
+// ——— Map pin ———
 const PIN_ICON = L.divIcon({
   html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 36" width="28" height="42">
     <path d="M12 0C5.373 0 0 5.373 0 12c0 8 12 24 12 24S24 20 24 12C24 5.373 18.627 0 12 0z" fill="#0d9488"/>
@@ -22,119 +29,117 @@ const PIN_ICON = L.divIcon({
 
 const DEFAULT_CENTER: [number, number] = [14.88, 102.016];
 
-// ——— Hospital boundary (actual campus corners, clockwise) ———
 const HOSPITAL_POLYGON: [number, number][] = [
-  [14.872057, 102.032653], // ซ้ายบน
-  [14.868710, 102.037165], // ขวาบน
-  [14.863138, 102.037573], // ขวาล่าง
-  [14.865121, 102.028199], // ซ้ายล่าง
+  [14.872057, 102.032653],
+  [14.868710, 102.037165],
+  [14.863138, 102.037573],
+  [14.865121, 102.028199],
 ];
+const WORLD_RING: [number, number][] = [[90,-180],[90,180],[-90,180],[-90,-180]];
 
-const WORLD_RING: [number, number][] = [
-  [90, -180], [90, 180], [-90, 180], [-90, -180],
-];
-
-// ——— Popup content — lazy-loads water data when popup opens ———
+// ——— Popup content ———
 function MeterPopupContent({
   locationId,
   buildingName,
+  deviceId,
+  canAdd,
+  onAddReading,
 }: {
   locationId: number;
   buildingName: string;
+  deviceId: number | undefined;
+  canAdd: boolean;
+  onAddReading: (deviceId: number, buildingName: string) => void;
 }) {
   const navigate = useNavigate();
-  const [usages, setUsages] = useState<DailyWaterUsageInterface[]>([]);
-  const [fetching, setFetching] = useState(true);
+  const [readings, setReadings] = useState<WaterItem[]>([]);
+  const [fetching, setFetching] = useState(false);
 
   useEffect(() => {
-    GetMeterLocationDetail(String(locationId)).then((res) => {
+    if (deviceId == null) return;
+    setFetching(true);
+    GetWaterValues(deviceId).then((res) => {
       setFetching(false);
       if (res?.status === 200) {
-        const raw = res.data?.data ?? res.data;
-        const list: DailyWaterUsageInterface[] =
-          raw?.DailyWaterUsage ?? raw?.daily_water_usage ?? [];
-        const sorted = [...list].sort(
-          (a, b) =>
-            new Date(b.Timestamp ?? "").getTime() -
-            new Date(a.Timestamp ?? "").getTime()
-        );
-        setUsages(sorted.slice(0, 2));
+        const raw: WaterItem[] = res.data?.data ?? res.data ?? [];
+        const sorted = [...raw]
+          .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+          .slice(0, 2);
+        setReadings(sorted);
       }
     });
-  }, [locationId]);
+  }, [deviceId]);
 
-  const row = (label: string, value: string, sub?: string) => (
-    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 5 }}>
-      <span style={{ fontSize: 11, color: "#6b7280" }}>{label}</span>
-      <div style={{ textAlign: "right" }}>
-        <span style={{ fontSize: 13, fontWeight: 700, color: "#0d9488" }}>{value}</span>
-        {sub && <span style={{ fontSize: 10, color: "#9ca3af", marginLeft: 4 }}>{sub}</span>}
-      </div>
-    </div>
-  );
+  const latest = readings[0];
+  const prev   = readings[1];
+  const usage  = latest && prev ? latest.meter_value - prev.meter_value : null;
 
   return (
     <div style={{ minWidth: 210, fontFamily: "inherit" }}>
       {/* Header */}
-      <p style={{ fontWeight: 700, fontSize: 13, color: "#111827", marginBottom: 10, paddingBottom: 8, borderBottom: "1px solid #f3f4f6" }}>
+      <p style={{ fontWeight: 700, fontSize: 13, color: "#111827", marginBottom: 10,
+                  paddingBottom: 8, borderBottom: "1px solid #f3f4f6" }}>
         {buildingName}
       </p>
 
-      {/* Water data */}
-      {fetching ? (
-        <p style={{ fontSize: 11, color: "#9ca3af", marginBottom: 10 }}>กำลังโหลดข้อมูล...</p>
-      ) : usages.length > 0 ? (
+      {!deviceId ? (
+        <p style={{ fontSize: 11, color: "#9ca3af", marginBottom: 10 }}>ไม่พบอุปกรณ์</p>
+      ) : fetching ? (
+        <p style={{ fontSize: 11, color: "#9ca3af", marginBottom: 10 }}>กำลังโหลด...</p>
+      ) : !latest ? (
+        <p style={{ fontSize: 11, color: "#9ca3af", marginBottom: 10 }}>ยังไม่มีข้อมูล</p>
+      ) : (
         <div style={{ marginBottom: 10 }}>
-          {row(
-            "ล่าสุด",
-            `${usages[0].Usage?.toFixed(2) ?? "—"} m³`,
-            usages[0].Timestamp ? dayjs(usages[0].Timestamp).format("D MMM") : undefined
-          )}
-          {usages[1] &&
-            row(
-              "ก่อนหน้า",
-              `${usages[1].Usage?.toFixed(2) ?? "—"} m³`,
-              usages[1].Timestamp ? dayjs(usages[1].Timestamp).format("D MMM") : undefined
-            )}
-          {usages[0].Usage != null && usages[1]?.Usage != null && (
-            <div style={{ marginTop: 6, padding: "4px 8px", background: "#f0fdf4", borderRadius: 6 }}>
-              <span style={{ fontSize: 11, color: "#166534" }}>
-                เปลี่ยนแปลง{" "}
-                <strong>
-                  {(usages[0].Usage - usages[1].Usage) >= 0 ? "+" : ""}
-                  {(usages[0].Usage - usages[1].Usage).toFixed(2)} m³
-                </strong>
+          <div style={{ display:"flex", justifyContent:"space-between", alignItems:"baseline", marginBottom: 5 }}>
+            <span style={{ fontSize: 11, color: "#6b7280" }}>ค่ามิเตอร์</span>
+            <div style={{ textAlign:"right" }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: "#0d9488" }}>
+                {latest.meter_value.toLocaleString()}
+              </span>
+              <span style={{ fontSize: 10, color: "#9ca3af", marginLeft: 3 }}>m³</span>
+            </div>
+          </div>
+          <p style={{ fontSize: 10, color: "#9ca3af", textAlign:"right", marginBottom: 8 }}>
+            {dayjs(latest.timestamp).format("D MMM YYYY HH:mm")}
+          </p>
+          {usage != null && (
+            <div style={{ padding:"5px 10px", background:"#f0fdf4", borderRadius: 7,
+                          display:"flex", justifyContent:"space-between", alignItems:"center" }}>
+              <span style={{ fontSize: 11, color: "#166534" }}>ใช้ล่าสุด</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: "#15803d" }}>
+                {usage} m³
               </span>
             </div>
           )}
         </div>
-      ) : (
-        <p style={{ fontSize: 11, color: "#9ca3af", marginBottom: 10 }}>ไม่มีข้อมูลการใช้น้ำ</p>
       )}
 
-      {/* Detail button */}
-      <button
-        onClick={() => navigate(`/water-detail?id=${locationId}`)}
-        style={{
-          width: "100%",
-          padding: "7px 0",
-          background: "#0d9488",
-          color: "white",
-          border: "none",
-          borderRadius: 7,
-          fontSize: 12,
-          fontWeight: 600,
-          cursor: "pointer",
-          letterSpacing: 0.3,
-        }}
-      >
-        ดูรายละเอียด →
-      </button>
+      <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
+        <button
+          onClick={() => navigate(`/water-detail?id=${locationId}`)}
+          style={{ flex: 1, padding:"7px 0", background:"#0d9488", color:"white",
+                   border:"none", borderRadius: 7, fontSize: 12, fontWeight: 600,
+                   cursor:"pointer", letterSpacing: 0.3 }}
+        >
+          ดูรายละเอียด →
+        </button>
+        {canAdd && deviceId != null && (
+          <button
+            onClick={() => onAddReading(deviceId, buildingName)}
+            style={{ padding:"7px 10px", background:"#f0fdf4", color:"#0d9488",
+                     border:"1.5px solid #0d9488", borderRadius: 7, fontSize: 12,
+                     fontWeight: 600, cursor:"pointer", display:"flex",
+                     alignItems:"center", gap: 3 }}
+          >
+            <Plus size={13} /> เพิ่ม
+          </button>
+        )}
+      </div>
     </div>
   );
 }
 
-// ——— Fit map to all markers ———
+// ——— Fit bounds ———
 function FitBounds({ positions }: { positions: [number, number][] }) {
   const map = useMap();
   useEffect(() => {
@@ -145,39 +150,87 @@ function FitBounds({ positions }: { positions: [number, number][] }) {
   return null;
 }
 
+// ——— Main page ———
 export default function MeterMap() {
   const { meters } = useAppContext();
+
+  const roleId = localStorage.getItem("role_id");
+  const canAdd = roleId === "1" || roleId === "2";
+
+  const [locationDeviceMap, setLocationDeviceMap] = useState<Record<number, number>>({});
+
+  useEffect(() => {
+    GetDevices().then((res) => {
+      if (res?.status === 200) {
+        const list: DeviceItem[] = res.data?.data ?? res.data ?? [];
+        const map: Record<number, number> = {};
+        list.forEach((d) => { if (d.location_id != null) map[d.location_id] = d.id; });
+        setLocationDeviceMap(map);
+      }
+    });
+  }, []);
 
   const positions = useMemo<[number, number][]>(
     () => meters.map((m) => [m.latitude, m.longitude]),
     [meters]
   );
 
+  // ——— Create modal ———
+  const [createTarget, setCreateTarget] = useState<{ deviceId: number; buildingName: string } | null>(null);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [fileList, setFileList] = useState<UploadFile[]>([]);
+  const [form] = Form.useForm();
+
+  const openCreate = (deviceId: number, buildingName: string) => {
+    setCreateTarget({ deviceId, buildingName });
+  };
+
+  const closeCreate = () => {
+    setCreateTarget(null);
+    form.resetFields();
+    setFileList([]);
+  };
+
+  const handleCreate = async () => {
+    if (!createTarget) return;
+    try {
+      const values = await form.validateFields();
+      setCreateLoading(true);
+      const payload: { meter_value: number; device_id: number; timestamp?: string; note?: string; image?: File } = {
+        meter_value: values.meter_value,
+        device_id: createTarget.deviceId,
+      };
+      if (values.timestamp) payload.timestamp = (values.timestamp as Dayjs).toISOString();
+      if (values.note)      payload.note = values.note;
+      if (fileList[0]?.originFileObj) payload.image = fileList[0].originFileObj;
+
+      const res = await CreateWaterValueManual(payload);
+      setCreateLoading(false);
+      if (res?.status === 200 || res?.status === 201) {
+        message.success(`บันทึกค่ามิเตอร์ "${createTarget.buildingName}" สำเร็จ`);
+        closeCreate();
+      } else {
+        message.error(res?.data?.error?.message ?? "เกิดข้อผิดพลาด");
+      }
+    } catch {
+      // validation failed
+    }
+  };
+
   return (
     <div className="relative" style={{ height: "calc(100vh - 48px)" }}>
-      <MapContainer
-        center={DEFAULT_CENTER}
-        zoom={15}
-        scrollWheelZoom
-        style={{ height: "100%", width: "100%" }}
-      >
+      <MapContainer center={DEFAULT_CENTER} zoom={15} scrollWheelZoom
+                    style={{ height: "100%", width: "100%" }}>
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
         />
-
         <FitBounds positions={positions} />
 
-        {/* Inverse mask — dim outside hospital */}
-        <Polygon
-          positions={[WORLD_RING, HOSPITAL_POLYGON]}
-          pathOptions={{ fillColor: "#000000", fillOpacity: 0.45, stroke: false }}
-        />
-        {/* Hospital border */}
-        <Polygon
-          positions={HOSPITAL_POLYGON}
-          pathOptions={{ color: "#0d9488", weight: 2, dashArray: "8 5", fillOpacity: 0 }}
-        />
+        <Polygon positions={[WORLD_RING, HOSPITAL_POLYGON]}
+                 pathOptions={{ fillColor:"#000", fillOpacity:0.45, stroke:false }} />
+        <Polygon positions={HOSPITAL_POLYGON}
+                 pathOptions={{ color:"#0d9488", weight:2, dashArray:"8 5", fillOpacity:0 }} />
 
         {meters.map((m) => (
           <Marker key={m.id} position={[m.latitude, m.longitude]} icon={PIN_ICON}>
@@ -188,12 +241,69 @@ export default function MeterMap() {
             </Tooltip>
             <Popup minWidth={220} maxWidth={260}>
               {m.id != null && (
-                <MeterPopupContent locationId={m.id} buildingName={m.building_name} />
+                <MeterPopupContent
+                  locationId={m.id}
+                  buildingName={m.building_name}
+                  deviceId={locationDeviceMap[m.id]}
+                  canAdd={canAdd}
+                  onAddReading={openCreate}
+                />
               )}
             </Popup>
           </Marker>
         ))}
       </MapContainer>
+
+      {/* ——— Create modal (ต้องอยู่นอก MapContainer) ——— */}
+      <Modal
+        title={`เพิ่มค่ามิเตอร์ — ${createTarget?.buildingName ?? ""}`}
+        open={createTarget != null}
+        onOk={handleCreate}
+        onCancel={closeCreate}
+        okText="บันทึก"
+        cancelText="ยกเลิก"
+        confirmLoading={createLoading}
+        okButtonProps={{ className: "!bg-teal-600 !border-teal-600 hover:!bg-teal-700" }}
+      >
+        <Form form={form} layout="vertical" className="mt-4">
+          <Form.Item
+            name="meter_value"
+            label="ค่ามิเตอร์ (m³)"
+            rules={[{ required: true, message: "กรุณากรอกค่ามิเตอร์" }]}
+          >
+            <InputNumber className="w-full" min={0} placeholder="เช่น 12345" />
+          </Form.Item>
+          <Form.Item name="timestamp" label="วันที่และเวลา (ปล่อยว่างเพื่อใช้เวลาปัจจุบัน)">
+            <DatePicker
+              showTime
+              className="w-full"
+              format="DD/MM/YYYY HH:mm"
+              disabledDate={(d) => d.isAfter(dayjs(), "day")}
+              placeholder="ไม่ระบุ = ใช้เวลาปัจจุบัน"
+            />
+          </Form.Item>
+          <Form.Item name="note" label="หมายเหตุ">
+            <Input.TextArea rows={2} placeholder="หมายเหตุ (ถ้ามี)" />
+          </Form.Item>
+          <Form.Item label="รูปภาพมิเตอร์ (ถ้ามี)">
+            <Upload.Dragger
+              accept="image/*"
+              maxCount={1}
+              fileList={fileList}
+              beforeUpload={() => false}
+              onChange={({ fileList: fl }) => setFileList(fl)}
+              listType="picture"
+            >
+              <p className="ant-upload-drag-icon flex justify-center">
+                <ImagePlus size={28} className="text-teal-500" />
+              </p>
+              <p className="ant-upload-text text-sm">คลิกหรือลากไฟล์รูปมาวางที่นี่</p>
+              <p className="ant-upload-hint text-xs text-gray-400">รองรับ JPG, PNG, WEBP (สูงสุด 1 ไฟล์)</p>
+            </Upload.Dragger>
+          </Form.Item>
+        </Form>
+      </Modal>
+
     </div>
   );
 }

--- a/frontend/src/pages/user/UserPage.tsx
+++ b/frontend/src/pages/user/UserPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { message } from "antd";
-import { Search, Pencil, Trash2, X, Users, Save } from "lucide-react";
+import { Search, Pencil, Trash2, X, Users, Save, Lock } from "lucide-react";
 import { GetUsers, DeleteUsersById, UpdateUserAssignment } from "../../services/https/user";
 import { GetRoles, GetPositions } from "../../services/https/api";
 import { UsersInterface } from "../../interfaces/IUser";
@@ -21,14 +21,17 @@ type Role = { id: number; role: string };
 type Position = { id: number; position: string };
 type EditState = { role_id: number | ""; position_id: number | "" };
 
+const ROLE_ADMIN    = 1;
 const ROLE_ENGINEER = 2;
 
 export default function UserPage() {
   const currentId     = Number(localStorage.getItem("id"));
   const currentRoleId = Number(localStorage.getItem("role_id"));
 
-  const canDelete = (u: UsersInterface) =>
-    currentRoleId !== ROLE_ENGINEER && u.id !== currentId;
+  const isAdminUser = (u: UsersInterface) => u.role_id === ROLE_ADMIN;
+  const canEdit     = (u: UsersInterface) => !isAdminUser(u);
+  const canDelete   = (u: UsersInterface) =>
+    !isAdminUser(u) && currentRoleId !== ROLE_ENGINEER && u.id !== currentId;
 
   const [msgApi, ctx] = message.useMessage();
   const [users, setUsers] = useState<UsersInterface[]>([]);
@@ -170,13 +173,19 @@ export default function UserPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
-                      <button
-                        onClick={() => openEdit(u)}
-                        title="แก้ไข"
-                        className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
-                      >
-                        <Pencil size={14} />
-                      </button>
+                      {canEdit(u) ? (
+                        <button
+                          onClick={() => openEdit(u)}
+                          title="แก้ไข"
+                          className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                      ) : (
+                        <span className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-300 dark:text-gray-600" title="ผู้ดูแลไม่สามารถแก้ไขได้">
+                          <Lock size={14} />
+                        </span>
+                      )}
                       {canDelete(u) && (
                         <button
                           onClick={() => setDeleteTarget(u)}
@@ -234,13 +243,19 @@ export default function UserPage() {
                         </td>
                         <td className="px-5 py-3.5">
                           <div className="flex items-center justify-end gap-1">
-                            <button
-                              onClick={() => openEdit(u)}
-                              title="แก้ไข"
-                              className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
-                            >
-                              <Pencil size={14} />
-                            </button>
+                            {canEdit(u) ? (
+                              <button
+                                onClick={() => openEdit(u)}
+                                title="แก้ไข"
+                                className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-teal-600 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-colors border-0 bg-transparent cursor-pointer"
+                              >
+                                <Pencil size={14} />
+                              </button>
+                            ) : (
+                              <span className="w-8 h-8 rounded-lg flex items-center justify-center text-gray-300 dark:text-gray-600" title="ผู้ดูแลไม่สามารถแก้ไขได้">
+                                <Lock size={14} />
+                              </span>
+                            )}
                             {canDelete(u) && (
                               <button
                                 onClick={() => setDeleteTarget(u)}

--- a/frontend/src/pages/water/Water.tsx
+++ b/frontend/src/pages/water/Water.tsx
@@ -1,10 +1,331 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer, Cell,
+} from "recharts";
+import {
+  Building2, Droplets, Clock, AlertCircle,
+  TrendingUp, TrendingDown, Minus, ArrowRight,
+} from "lucide-react";
+import { useAppContext } from "../../contexts/AppContextDef";
+import type { WaterValueResponse } from "../../interfaces/InterfaceAll";
 
-const WaterDashboard = () => {
-    return (
-      <div>
-        Hello Water Dashboard
+// ——— Types ———
+interface BuildingStat {
+  id: number;
+  name: string;
+  latest: WaterValueResponse | null;
+  prev: WaterValueResponse | null;
+  dailyUsage: number | null;
+  pendingCount: number;
+  totalReadings: number;
+}
+
+// ——— Stat card ———
+function SummaryCard({
+  icon, label, value, sub, accent,
+}: {
+  icon: React.ReactNode; label: string; value: string | number;
+  sub?: string; accent?: string;
+}) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{label}</span>
+        <span className={accent ?? "text-teal-500"}>{icon}</span>
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
     </div>
   );
-};
+}
 
-export default WaterDashboard;
+// ——— Building card ———
+function BuildingCard({ stat, onClick }: { stat: BuildingStat; onClick: () => void }) {
+  const trend = stat.dailyUsage != null
+    ? stat.dailyUsage > 0 ? "up" : stat.dailyUsage < 0 ? "down" : "flat"
+    : null;
+
+  const statusCls = stat.latest
+    ? stat.latest.status_id === 2
+      ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300"
+      : stat.latest.status_id === 3
+        ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300"
+        : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+    : "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400";
+
+  const statusLabel = stat.latest
+    ? stat.latest.status_id === 2 ? "อนุมัติแล้ว"
+      : stat.latest.status_id === 3 ? "ไม่อนุมัติ"
+      : "รออนุมัติ"
+    : "ไม่มีข้อมูล";
+
+  return (
+    <div
+      onClick={onClick}
+      className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm border border-gray-100 dark:border-gray-700 hover:border-teal-400 dark:hover:border-teal-500 hover:shadow-md transition-all cursor-pointer group"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2 mb-4">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-8 h-8 rounded-lg bg-teal-50 dark:bg-teal-900/30 flex items-center justify-center shrink-0">
+            <Building2 size={15} className="text-teal-600 dark:text-teal-400" />
+          </div>
+          <span className="text-sm font-semibold text-gray-800 dark:text-white leading-tight line-clamp-2">
+            {stat.name}
+          </span>
+        </div>
+        <ArrowRight
+          size={15}
+          className="text-gray-300 dark:text-gray-600 group-hover:text-teal-500 transition-colors shrink-0 mt-0.5"
+        />
+      </div>
+
+      {/* Meter value */}
+      {stat.latest ? (
+        <>
+          <div className="flex items-baseline gap-1 mb-1">
+            <span className="text-2xl font-bold text-teal-600 dark:text-teal-400">
+              {stat.latest.meter_value.toLocaleString()}
+            </span>
+            <span className="text-xs text-gray-400">m³</span>
+          </div>
+          <p className="text-xs text-gray-400 mb-3">
+            {dayjs(stat.latest.timestamp).format("D MMM YYYY HH:mm")}
+          </p>
+        </>
+      ) : (
+        <p className="text-sm text-gray-400 mb-3">ยังไม่มีข้อมูล</p>
+      )}
+
+      {/* Daily usage + status */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        {stat.dailyUsage != null ? (
+          <div className="flex items-center gap-1">
+            {trend === "up" && <TrendingUp size={13} className="text-orange-500" />}
+            {trend === "down" && <TrendingDown size={13} className="text-teal-500" />}
+            {trend === "flat" && <Minus size={13} className="text-gray-400" />}
+            <span className={`text-xs font-medium ${
+              trend === "up" ? "text-orange-500"
+              : trend === "down" ? "text-teal-600"
+              : "text-gray-400"
+            }`}>
+              {stat.dailyUsage > 0 ? "+" : ""}{stat.dailyUsage} m³
+            </span>
+            <span className="text-xs text-gray-400">จากครั้งก่อน</span>
+          </div>
+        ) : (
+          <span className="text-xs text-gray-400">—</span>
+        )}
+        <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusCls}`}>
+          {statusLabel}
+        </span>
+      </div>
+
+      {/* Pending badge */}
+      {stat.pendingCount > 0 && (
+        <div className="mt-3 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+          <AlertCircle size={11} />
+          รอการอนุมัติ {stat.pendingCount} รายการ
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ——— Custom bar label ———
+function CustomBarLabel({ x, y, width, value }: { x?: number; y?: number; width?: number; value?: number }) {
+  if (!value) return null;
+  return (
+    <text x={(x ?? 0) + (width ?? 0) + 6} y={(y ?? 0) + 11} fontSize={11} fill="#9ca3af">
+      {value.toLocaleString()}
+    </text>
+  );
+}
+
+// ——— Page ———
+export default function WaterDashboard() {
+  const navigate = useNavigate();
+  const { meters, waterusage, loading } = useAppContext();
+
+  // Group readings by location_id, sorted desc
+  const readingsByLocation = useMemo(() => {
+    const map: Record<number, WaterValueResponse[]> = {};
+    waterusage.forEach((r) => {
+      const locId = r.device?.location_id;
+      if (locId == null) return;
+      if (!map[locId]) map[locId] = [];
+      map[locId].push(r);
+    });
+    Object.values(map).forEach((arr) =>
+      arr.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    );
+    return map;
+  }, [waterusage]);
+
+  // Per-building stats
+  const buildingStats = useMemo<BuildingStat[]>(() => {
+    return meters
+      .filter((m) => m.id != null)
+      .map((m) => {
+        const readings = readingsByLocation[m.id!] ?? [];
+        const latest = readings[0] ?? null;
+        const prev   = readings[1] ?? null;
+        return {
+          id:            m.id!,
+          name:          m.building_name,
+          latest,
+          prev,
+          dailyUsage:    latest && prev ? latest.meter_value - prev.meter_value : null,
+          pendingCount:  readings.filter((r) => r.status_id === 1).length,
+          totalReadings: readings.length,
+        };
+      });
+  }, [meters, readingsByLocation]);
+
+  // Summary stats
+  const totalPending   = buildingStats.reduce((s, b) => s + b.pendingCount, 0);
+  const buildingsWithData = buildingStats.filter((b) => b.latest != null).length;
+  const totalReadings  = waterusage.length;
+
+  // Chart data: daily usage per building (only those with ≥ 2 readings)
+  const chartData = useMemo(() =>
+    buildingStats
+      .filter((b) => b.dailyUsage != null)
+      .map((b) => ({
+        name: b.name.replace(/^อาคาร/, "").trim(),
+        fullName: b.name,
+        usage: b.dailyUsage!,
+        id: b.id,
+      }))
+      .sort((a, b) => b.usage - a.usage),
+  [buildingStats]);
+
+  const barColors = ["#0d9488","#14b8a6","#2dd4bf","#5eead4","#99f6e4","#ccfbf1","#f0fdf4"];
+
+  return (
+    <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-4 sm:p-6 space-y-6">
+
+      {/* ——— Page header ——— */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">ภาพรวมการใช้น้ำ</h1>
+          <p className="text-xs text-gray-400 mt-0.5">ข้อมูลทุกอาคารในโรงพยาบาล</p>
+        </div>
+        <span className="text-xs text-gray-400 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-3 py-1.5 rounded-lg">
+          {dayjs().format("D MMM YYYY")}
+        </span>
+      </div>
+
+      {/* ——— Summary cards ——— */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <SummaryCard
+          icon={<Building2 size={16} />}
+          label="อาคารทั้งหมด"
+          value={meters.length}
+          sub={`มีข้อมูล ${buildingsWithData} อาคาร`}
+        />
+        <SummaryCard
+          icon={<Droplets size={16} />}
+          label="บันทึกทั้งหมด"
+          value={totalReadings.toLocaleString()}
+          sub="ทุกอาคาร"
+        />
+        <SummaryCard
+          icon={<AlertCircle size={16} />}
+          label="รออนุมัติ"
+          value={totalPending}
+          sub="รายการทั้งหมด"
+          accent={totalPending > 0 ? "text-amber-500" : "text-gray-400"}
+        />
+        <SummaryCard
+          icon={<Clock size={16} />}
+          label="อัปเดตล่าสุด"
+          value={
+            waterusage.length > 0
+              ? dayjs(
+                  [...waterusage].sort(
+                    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+                  )[0].timestamp
+                ).format("HH:mm")
+              : "—"
+          }
+          sub={
+            waterusage.length > 0
+              ? dayjs(
+                  [...waterusage].sort(
+                    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+                  )[0].timestamp
+                ).format("D MMM YYYY")
+              : undefined
+          }
+        />
+      </div>
+
+      {/* ——— Bar chart ——— */}
+      {chartData.length > 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-800 dark:text-white mb-4">
+            การใช้น้ำจากครั้งก่อน (m³) — แยกตามอาคาร
+          </h2>
+          <ResponsiveContainer width="100%" height={Math.max(180, chartData.length * 42)}>
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 0, right: 60, bottom: 0, left: 8 }}
+            >
+              <CartesianGrid horizontal={false} strokeDasharray="3 3" stroke="#f3f4f6" />
+              <XAxis type="number" tick={{ fontSize: 10, fill: "#9ca3af" }} tickLine={false} axisLine={false} />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={130}
+                tick={{ fontSize: 11, fill: "#6b7280" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                contentStyle={{ borderRadius: 8, fontSize: 12, border: "1px solid #e5e7eb" }}
+                formatter={(v: number, _: string, item) => [
+                  `${v} m³`, (item.payload as { fullName: string } | undefined)?.fullName ?? "",
+                ]}
+                cursor={{ fill: "#f0fdf4" }}
+              />
+              <Bar dataKey="usage" radius={[0, 6, 6, 0]} label={<CustomBarLabel />}>
+                {chartData.map((_, i) => (
+                  <Cell key={i} fill={barColors[i % barColors.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* ——— Building cards ——— */}
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+          รายละเอียดแต่ละอาคาร
+        </h2>
+        {loading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {[...Array(8)].map((_, i) => (
+              <div key={i} className="bg-white dark:bg-gray-800 rounded-2xl p-5 h-40 animate-pulse border border-gray-100 dark:border-gray-700" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {buildingStats.map((stat) => (
+              <BuildingCard
+                key={stat.id}
+                stat={stat}
+                onClick={() => navigate(`/water-detail?id=${stat.id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/water/WaterDetail.tsx
+++ b/frontend/src/pages/water/WaterDetail.tsx
@@ -1,38 +1,25 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
+import { DatePicker, Form, InputNumber, Input, Modal, message, Button, Upload, Image } from "antd";
+import type { UploadFile } from "antd";
+import { Plus, ImagePlus } from "lucide-react";
 import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as ChartTooltip,
-  ResponsiveContainer,
+  AreaChart, Area, XAxis, YAxis, CartesianGrid,
+  Tooltip as ChartTooltip, ResponsiveContainer,
 } from "recharts";
 import { ArrowLeft, MapPin, Cpu, Activity, Droplets, BarChart2, Clock } from "lucide-react";
 import { useAppContext } from "../../contexts/AppContextDef";
-import { GetWaterValues } from "../../services/https/waterValue";
+import { GetWaterValues, CreateWaterValueManual } from "../../services/https/waterValue";
+import { GetDevices } from "../../services/https/device";
 
-// ——— Types for /water-values response ———
-interface WaterValueStatus {
-  id: number;
-  status_value: string;
-  description: string;
-}
+const { RangePicker } = DatePicker;
+const apiBase = import.meta.env.VITE_API_BASE_URL as string;
 
-interface WaterValueDevice {
-  id: number;
-  mac_address: string;
-  location_id: number | null;
-}
-
-interface WaterValueUser {
-  id: number;
-  first_name: string;
-  last_name: string;
-}
-
+// ——— Types matching /water-values response ———
+interface WaterValueStatus { id: number; status_value: string; description: string }
+interface WaterValueDevice { id: number; mac_address: string; location_id: number | null }
+interface WaterValueUser   { id: number; first_name: string; last_name: string }
 interface WaterValueItem {
   id: number;
   meter_value: number;
@@ -50,7 +37,7 @@ interface WaterValueItem {
   updated_at: string;
 }
 
-// ——— Status badge config ———
+// ——— Status badge ———
 const STATUS_CLS: Record<number, string> = {
   1: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
   2: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
@@ -58,20 +45,9 @@ const STATUS_CLS: Record<number, string> = {
 };
 
 // ——— Stat card ———
-function StatCard({
-  icon,
-  label,
-  value,
-  unit,
-  sub,
-  loading,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: string | number | null;
-  unit?: string;
-  sub?: string;
-  loading?: boolean;
+function StatCard({ icon, label, value, unit, sub, loading }: {
+  icon: React.ReactNode; label: string; value: string | number | null;
+  unit?: string; sub?: string; loading?: boolean;
 }) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
@@ -84,9 +60,7 @@ function StatCard({
       ) : (
         <p className="text-2xl font-bold text-gray-900 dark:text-white">
           {value ?? "—"}
-          {value != null && unit && (
-            <span className="text-sm font-normal text-gray-400 ml-1">{unit}</span>
-          )}
+          {value != null && unit && <span className="text-sm font-normal text-gray-400 ml-1">{unit}</span>}
         </p>
       )}
       {sub && !loading && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
@@ -100,80 +74,143 @@ export default function WaterDetailPage() {
   const navigate = useNavigate();
   const locationId = Number(searchParams.get("id"));
 
-  const { meters, waterDaily } = useAppContext();
-
-  // Meter & device info from context
+  const { meters } = useAppContext();
   const meter = meters.find((m) => m.id === locationId);
-  const ctxDevice = waterDaily.find(
-    (d) =>
-      d.MeterLocation?.id === locationId ||
-      (d.MeterLocation as unknown as { ID?: number })?.ID === locationId
-  );
-  const deviceId = ctxDevice?.ID;
 
-  // ——— Fetch readings from /water-values?device_id=X ———
+  // ——— Device for this location ———
+  const [deviceId, setDeviceId]   = useState<number | null>(null);
+  const [macAddress, setMacAddress] = useState("");
+  const [loadingDevice, setLoadingDevice] = useState(true);
+
+  // ——— Create modal ———
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [fileList, setFileList] = useState<UploadFile[]>([]);
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (!locationId) return;
+    setLoadingDevice(true);
+    GetDevices().then((res) => {
+      setLoadingDevice(false);
+      if (res?.status === 200) {
+        const list: Array<{ id: number; mac_address: string; location_id: number | null }> =
+          res.data?.data ?? res.data ?? [];
+        const dev = list.find((d) => d.location_id === locationId);
+        if (dev) { setDeviceId(dev.id); setMacAddress(dev.mac_address); }
+      }
+    });
+  }, [locationId]);
+
+  // ——— Date range — default: last 30 days ———
+  const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>([
+    dayjs().subtract(30, "day"),
+    dayjs(),
+  ]);
+
+  // ——— Fetch readings ———
   const [readings, setReadings] = useState<WaterValueItem[]>([]);
   const [loadingReadings, setLoadingReadings] = useState(false);
 
   useEffect(() => {
-    if (!deviceId) return;
+    if (deviceId == null) return;
     setLoadingReadings(true);
-    GetWaterValues(deviceId).then((res) => {
+    GetWaterValues(
+      deviceId,
+      undefined,
+      dateRange[0].format("YYYY-MM-DD"),
+      dateRange[1].format("YYYY-MM-DD"),
+    ).then((res) => {
       setLoadingReadings(false);
       if (res?.status === 200) {
         const raw: WaterValueItem[] = res.data?.data ?? res.data ?? [];
-        const sorted = [...raw].sort(
-          (a, b) =>
-            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+        setReadings(
+          [...raw].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
         );
-        setReadings(sorted.slice(0, 50));
       }
     });
-  }, [deviceId]);
+  }, [deviceId, dateRange]);
 
-  // ——— Daily usage from context (waterDaily already preloaded) ———
-  const dailyData = useMemo(() => {
-    const raw = ctxDevice?.DailyWaterUsage ?? [];
-    return [...raw].sort(
-      (a, b) =>
-        new Date(b.Timestamp ?? "").getTime() - new Date(a.Timestamp ?? "").getTime()
-    );
-  }, [ctxDevice]);
+  // ——— Daily usage computed from consecutive readings ———
+  // meter_value คือค่าสะสม (odometer) ไม่มีติดลบ
+  const chartData = useMemo(() => {
+    const byDay = new Map<string, number>();
+    // readings sorted desc — เก็บ first (= ล่าสุดของวัน)
+    readings.forEach((r) => {
+      const day = dayjs(r.timestamp).format("YYYY-MM-DD");
+      if (!byDay.has(day)) byDay.set(day, r.meter_value);
+    });
+    const days = [...byDay.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+    const result: { date: string; ปริมาณ: number }[] = [];
+    for (let i = 1; i < days.length; i++) {
+      const diff = days[i][1] - days[i - 1][1];
+      if (diff >= 0) result.push({ date: dayjs(days[i][0]).format("D MMM"), ปริมาณ: diff });
+    }
+    return result;
+  }, [readings]);
 
   // ——— Stats ———
+  const loading       = loadingDevice || loadingReadings;
   const latestReading = readings[0];
-  const latestDaily = dailyData[0];
-  const avgUsage =
-    dailyData.length > 0
-      ? dailyData.reduce((s, d) => s + (d.Usage ?? 0), 0) / dailyData.length
-      : null;
+  const latestDaily   = chartData[chartData.length - 1];
+  const avgUsage      = chartData.length > 0
+    ? chartData.reduce((s, d) => s + d.ปริมาณ, 0) / chartData.length
+    : null;
 
-  // ——— Chart data — last 30 days ascending ———
-  const chartData = dailyData
-    .slice(0, 30)
-    .reverse()
-    .map((d) => ({
-      date: dayjs(d.Timestamp).format("D MMM"),
-      ปริมาณ: Number((d.Usage ?? 0).toFixed(3)),
-    }));
+  const resetCreateModal = () => {
+    form.resetFields();
+    setFileList([]);
+    setCreateOpen(false);
+  };
+
+  const handleCreate = async () => {
+    try {
+      const values = await form.validateFields();
+      if (!deviceId) { message.error("ไม่พบอุปกรณ์ที่เชื่อมต่อกับจุดนี้"); return; }
+      setCreateLoading(true);
+      const payload: { meter_value: number; device_id: number; timestamp?: string; note?: string; image?: File } = {
+        meter_value: values.meter_value,
+        device_id: deviceId,
+      };
+      if (values.timestamp) payload.timestamp = (values.timestamp as Dayjs).toISOString();
+      if (values.note)      payload.note = values.note;
+      if (fileList[0]?.originFileObj) payload.image = fileList[0].originFileObj;
+
+      const res = await CreateWaterValueManual(payload);
+      setCreateLoading(false);
+      if (res?.status === 200 || res?.status === 201) {
+        message.success("บันทึกค่ามิเตอร์สำเร็จ");
+        resetCreateModal();
+        setReadings([]);
+        setLoadingReadings(true);
+        GetWaterValues(deviceId, undefined, dateRange[0].format("YYYY-MM-DD"), dateRange[1].format("YYYY-MM-DD"))
+          .then((r) => {
+            setLoadingReadings(false);
+            if (r?.status === 200) {
+              const raw: WaterValueItem[] = r.data?.data ?? r.data ?? [];
+              setReadings([...raw].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()));
+            }
+          });
+      } else {
+        message.error(res?.data?.error?.message ?? "เกิดข้อผิดพลาด");
+      }
+    } catch {
+      // validation failed
+    }
+  };
 
   if (!locationId) {
-    return (
-      <div className="flex items-center justify-center h-64 text-gray-400">
-        ไม่พบข้อมูลอาคาร
-      </div>
-    );
+    return <div className="flex items-center justify-center h-64 text-gray-400">ไม่พบข้อมูลอาคาร</div>;
   }
 
   return (
     <div className="min-h-full bg-gray-50 dark:bg-gray-950 p-4 sm:p-6 space-y-5">
+
       {/* ——— Back ——— */}
-      <button
-        onClick={() => navigate(-1)}
-        className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
-      >
-        <ArrowLeft size={15} />
-        ย้อนกลับ
+      <button onClick={() => navigate(-1)}
+        className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors">
+        <ArrowLeft size={15} /> ย้อนกลับ
       </button>
 
       {/* ——— Building header ——— */}
@@ -191,112 +228,100 @@ export default function WaterDetailPage() {
                 {meter.latitude.toFixed(6)}, {meter.longitude.toFixed(6)}
               </p>
             )}
-            {ctxDevice?.MacAddress && (
+            {macAddress && (
               <div className="flex items-center gap-1.5 ml-7 mt-1.5">
                 <Cpu size={12} className="text-gray-400" />
-                <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
-                  {ctxDevice.MacAddress}
-                </span>
+                <span className="text-xs font-mono text-gray-500 dark:text-gray-400">{macAddress}</span>
               </div>
             )}
           </div>
-          <div className="flex items-center gap-1.5 text-xs text-gray-400 bg-gray-50 dark:bg-gray-700 px-3 py-1.5 rounded-lg">
-            <MapPin size={12} />
-            <span>จุดมิเตอร์ #{locationId}</span>
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="flex items-center gap-1.5 text-xs text-gray-400 bg-gray-50 dark:bg-gray-700 px-3 py-1.5 rounded-lg">
+              <MapPin size={12} /><span>จุดมิเตอร์ #{locationId}</span>
+            </div>
+            {deviceId != null && (
+              <Button
+                type="primary"
+                icon={<Plus size={14} />}
+                onClick={() => setCreateOpen(true)}
+                className="!bg-teal-600 !border-teal-600 hover:!bg-teal-700"
+              >
+                เพิ่มค่ามิเตอร์
+              </Button>
+            )}
           </div>
         </div>
       </div>
 
+      {/* ——— Date range picker ——— */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl px-5 py-4 shadow-sm border border-gray-100 dark:border-gray-700 flex items-center gap-3 flex-wrap">
+        <span className="text-sm font-medium text-gray-600 dark:text-gray-300 shrink-0">ช่วงวันที่</span>
+        <RangePicker
+          value={dateRange}
+          onChange={(vals) => {
+            if (vals && vals[0] && vals[1]) setDateRange([vals[0], vals[1]]);
+          }}
+          format="DD/MM/YYYY"
+          allowClear={false}
+          disabledDate={(d) => d.isAfter(dayjs(), "day")}
+          presets={[
+            { label: "7 วันล่าสุด",  value: [dayjs().subtract(7,  "day"), dayjs()] },
+            { label: "30 วันล่าสุด", value: [dayjs().subtract(30, "day"), dayjs()] },
+            { label: "3 เดือนล่าสุด",value: [dayjs().subtract(3,  "month"), dayjs()] },
+            { label: "ปีนี้",        value: [dayjs().startOf("year"), dayjs()] },
+          ]}
+        />
+        {loadingReadings && (
+          <span className="text-xs text-gray-400 animate-pulse">กำลังโหลด...</span>
+        )}
+      </div>
+
       {/* ——— Stat cards ——— */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard
-          icon={<Activity size={15} />}
-          label="ค่ามิเตอร์ล่าสุด"
-          value={latestReading ? latestReading.meter_value.toLocaleString() : null}
-          unit="m³"
+        <StatCard icon={<Activity size={15} />} label="ค่ามิเตอร์ล่าสุด"
+          value={latestReading ? latestReading.meter_value.toLocaleString() : null} unit="m³"
           sub={latestReading ? dayjs(latestReading.timestamp).format("D MMM YYYY HH:mm") : undefined}
-          loading={loadingReadings}
-        />
-        <StatCard
-          icon={<Droplets size={15} />}
-          label="ปริมาณล่าสุด (รายวัน)"
-          value={latestDaily?.Usage != null ? latestDaily.Usage.toFixed(3) : null}
-          unit="m³"
-          sub={latestDaily?.Timestamp ? dayjs(latestDaily.Timestamp).format("D MMM YYYY") : undefined}
-        />
-        <StatCard
-          icon={<BarChart2 size={15} />}
-          label="เฉลี่ย/วัน"
-          value={avgUsage != null ? avgUsage.toFixed(3) : null}
-          unit="m³"
-          sub={dailyData.length > 0 ? `จาก ${dailyData.length} วัน` : undefined}
-        />
-        <StatCard
-          icon={<Clock size={15} />}
-          label="บันทึกทั้งหมด"
-          value={!loadingReadings && readings.length > 0 ? readings.length : null}
-          unit="ครั้ง"
-          sub="(สูงสุด 50 รายการล่าสุด)"
-          loading={loadingReadings}
-        />
+          loading={loading} />
+        <StatCard icon={<Droplets size={15} />} label="ใช้ล่าสุด (รายวัน)"
+          value={latestDaily ? latestDaily.ปริมาณ : null} unit="m³"
+          sub={latestDaily?.date} loading={loading} />
+        <StatCard icon={<BarChart2 size={15} />} label="เฉลี่ย/วัน"
+          value={avgUsage != null ? avgUsage.toFixed(1) : null} unit="m³"
+          sub={chartData.length > 0 ? `จาก ${chartData.length} วัน` : undefined}
+          loading={loading} />
+        <StatCard icon={<Clock size={15} />} label="บันทึกทั้งหมด"
+          value={!loading && readings.length > 0 ? readings.length : null} unit="ครั้ง"
+          loading={loading} />
       </div>
 
       {/* ——— Daily usage chart ——— */}
       <div className="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-gray-100 dark:border-gray-700">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-sm font-semibold text-gray-800 dark:text-white">
-            กราฟการใช้น้ำรายวัน
-          </h2>
-          {chartData.length > 0 && (
-            <span className="text-xs text-gray-400">{chartData.length} วันล่าสุด</span>
-          )}
+          <h2 className="text-sm font-semibold text-gray-800 dark:text-white">กราฟการใช้น้ำรายวัน</h2>
+          {chartData.length > 0 && <span className="text-xs text-gray-400">{chartData.length} วัน</span>}
         </div>
-
-        {chartData.length === 0 ? (
-          <div className="h-52 flex items-center justify-center text-sm text-gray-400">
-            ไม่มีข้อมูลการใช้น้ำรายวัน
-          </div>
+        {loading ? (
+          <div className="h-52 flex items-center justify-center text-sm text-gray-400 animate-pulse">กำลังโหลด...</div>
+        ) : chartData.length === 0 ? (
+          <div className="h-52 flex items-center justify-center text-sm text-gray-400">ไม่มีข้อมูลในช่วงที่เลือก</div>
         ) : (
           <ResponsiveContainer width="100%" height={220}>
             <AreaChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
               <defs>
                 <linearGradient id="usageGrad" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#0d9488" stopOpacity={0.28} />
+                  <stop offset="5%"  stopColor="#0d9488" stopOpacity={0.28} />
                   <stop offset="95%" stopColor="#0d9488" stopOpacity={0} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
-              <XAxis
-                dataKey="date"
-                tick={{ fontSize: 10, fill: "#9ca3af" }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                tick={{ fontSize: 10, fill: "#9ca3af" }}
-                tickLine={false}
-                axisLine={false}
-                unit=" m³"
-                width={64}
-              />
+              <XAxis dataKey="date" tick={{ fontSize:10, fill:"#9ca3af" }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize:10, fill:"#9ca3af" }} tickLine={false} axisLine={false} unit=" m³" width={56} />
               <ChartTooltip
-                contentStyle={{
-                  borderRadius: 8,
-                  fontSize: 12,
-                  border: "1px solid #e5e7eb",
-                  boxShadow: "0 2px 8px rgba(0,0,0,.08)",
-                }}
+                contentStyle={{ borderRadius:8, fontSize:12, border:"1px solid #e5e7eb", boxShadow:"0 2px 8px rgba(0,0,0,.08)" }}
                 formatter={(v: number) => [`${v} m³`, "ปริมาณ"]}
               />
-              <Area
-                type="monotone"
-                dataKey="ปริมาณ"
-                stroke="#0d9488"
-                strokeWidth={2.5}
-                fill="url(#usageGrad)"
-                dot={false}
-                activeDot={{ r: 4, fill: "#0d9488" }}
-              />
+              <Area type="monotone" dataKey="ปริมาณ" stroke="#0d9488" strokeWidth={2.5}
+                fill="url(#usageGrad)" dot={false} activeDot={{ r:4, fill:"#0d9488" }} />
             </AreaChart>
           </ResponsiveContainer>
         )}
@@ -306,19 +331,15 @@ export default function WaterDetailPage() {
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center gap-2">
           <Cpu size={14} className="text-teal-500" />
-          <h2 className="text-sm font-semibold text-gray-800 dark:text-white">
-            ประวัติค่ามิเตอร์
-          </h2>
-          <span className="ml-auto text-xs text-gray-400">50 รายการล่าสุด</span>
+          <h2 className="text-sm font-semibold text-gray-800 dark:text-white">ประวัติค่ามิเตอร์</h2>
+          {readings.length > 0 && <span className="ml-auto text-xs text-gray-400">{readings.length} รายการ</span>}
         </div>
 
-        {loadingReadings ? (
-          <div className="px-5 py-12 text-center text-sm text-gray-400 animate-pulse">
-            กำลังโหลด...
-          </div>
+        {loading ? (
+          <div className="px-5 py-12 text-center text-sm text-gray-400 animate-pulse">กำลังโหลด...</div>
         ) : readings.length === 0 ? (
           <div className="px-5 py-12 text-center text-sm text-gray-400">
-            {deviceId ? "ไม่มีข้อมูลการบันทึก" : "ไม่พบอุปกรณ์ที่เชื่อมต่อกับจุดนี้"}
+            {deviceId != null ? "ไม่มีข้อมูลในช่วงวันที่เลือก" : "ไม่พบอุปกรณ์ที่เชื่อมต่อกับจุดนี้"}
           </div>
         ) : (
           <div className="overflow-x-auto">
@@ -326,6 +347,7 @@ export default function WaterDetailPage() {
               <thead>
                 <tr className="bg-gray-50 dark:bg-gray-700/50 text-left text-xs text-gray-500 dark:text-gray-400">
                   <th className="px-5 py-3 font-medium">#</th>
+                  <th className="px-5 py-3 font-medium">รูป</th>
                   <th className="px-5 py-3 font-medium">วันที่</th>
                   <th className="px-5 py-3 font-medium">ค่ามิเตอร์</th>
                   <th className="px-5 py-3 font-medium">สถานะ</th>
@@ -335,11 +357,21 @@ export default function WaterDetailPage() {
               </thead>
               <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
                 {readings.map((r, i) => (
-                  <tr
-                    key={r.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
-                  >
+                  <tr key={r.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors">
                     <td className="px-5 py-3 text-gray-400 text-xs">{i + 1}</td>
+                    <td className="px-5 py-3">
+                      {r.image_path ? (
+                        <Image
+                          src={`${apiBase}/${r.image_path}`}
+                          width={48}
+                          height={48}
+                          className="!rounded-md object-cover cursor-pointer"
+                          preview={{ mask: false }}
+                        />
+                      ) : (
+                        <span className="text-gray-300 dark:text-gray-600">—</span>
+                      )}
+                    </td>
                     <td className="px-5 py-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
                       {dayjs(r.timestamp).format("D MMM YYYY HH:mm")}
                     </td>
@@ -348,14 +380,10 @@ export default function WaterDetailPage() {
                     </td>
                     <td className="px-5 py-3">
                       {r.status ? (
-                        <span
-                          className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CLS[r.status_id] ?? "bg-gray-100 text-gray-600"}`}
-                        >
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CLS[r.status_id] ?? "bg-gray-100 text-gray-600"}`}>
                           {r.status.status_value}
                         </span>
-                      ) : (
-                        <span className="text-gray-400 text-xs">—</span>
-                      )}
+                      ) : <span className="text-gray-400 text-xs">—</span>}
                     </td>
                     <td className="px-5 py-3 text-xs text-gray-500 dark:text-gray-400">
                       {r.user ? `${r.user.first_name} ${r.user.last_name}` : "—"}
@@ -370,6 +398,56 @@ export default function WaterDetailPage() {
           </div>
         )}
       </div>
+
+      {/* ——— Create modal ——— */}
+      <Modal
+        title="เพิ่มค่ามิเตอร์ด้วยตนเอง"
+        open={createOpen}
+        onOk={handleCreate}
+        onCancel={resetCreateModal}
+        okText="บันทึก"
+        cancelText="ยกเลิก"
+        confirmLoading={createLoading}
+        okButtonProps={{ className: "!bg-teal-600 !border-teal-600 hover:!bg-teal-700" }}
+      >
+        <Form form={form} layout="vertical" className="mt-4">
+          <Form.Item
+            name="meter_value"
+            label="ค่ามิเตอร์ (m³)"
+            rules={[{ required: true, message: "กรุณากรอกค่ามิเตอร์" }]}
+          >
+            <InputNumber className="w-full" min={0} placeholder="เช่น 12345" />
+          </Form.Item>
+          <Form.Item name="timestamp" label="วันที่และเวลา (ปล่อยว่างเพื่อใช้เวลาปัจจุบัน)">
+            <DatePicker
+              showTime
+              className="w-full"
+              format="DD/MM/YYYY HH:mm"
+              disabledDate={(d) => d.isAfter(dayjs(), "day")}
+              placeholder="ไม่ระบุ = ใช้เวลาปัจจุบัน"
+            />
+          </Form.Item>
+          <Form.Item name="note" label="หมายเหตุ">
+            <Input.TextArea rows={2} placeholder="หมายเหตุ (ถ้ามี)" />
+          </Form.Item>
+          <Form.Item label="รูปภาพมิเตอร์ (ถ้ามี)">
+            <Upload.Dragger
+              accept="image/*"
+              maxCount={1}
+              fileList={fileList}
+              beforeUpload={() => false}
+              onChange={({ fileList: fl }) => setFileList(fl)}
+              listType="picture"
+            >
+              <p className="ant-upload-drag-icon flex justify-center">
+                <ImagePlus size={28} className="text-teal-500" />
+              </p>
+              <p className="ant-upload-text text-sm">คลิกหรือลากไฟล์รูปมาวางที่นี่</p>
+              <p className="ant-upload-hint text-xs text-gray-400">รองรับ JPG, PNG, WEBP (สูงสุด 1 ไฟล์)</p>
+            </Upload.Dragger>
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/services/https/maintain.ts
+++ b/frontend/src/services/https/maintain.ts
@@ -59,3 +59,22 @@ export async function DeleteMaintainLog(id: number) {
     .then((res) => res)
     .catch((e) => e.response);
 }
+
+export async function CreateMaintainLogReport(data: {
+  title: string;
+  location_text: string;
+  location_id?: number | null;
+  image?: File;
+}) {
+  const form = new FormData();
+  form.append("title", data.title);
+  form.append("location_text", data.location_text);
+  if (data.location_id != null) form.append("location_id", String(data.location_id));
+  if (data.image) form.append("image", data.image);
+  return await axios
+    .post(`${apiUrl}/maintain-logs/report`, form, {
+      headers: { ...authHeader().headers, "Content-Type": "multipart/form-data" },
+    })
+    .then((res) => res)
+    .catch((e) => e.response);
+}

--- a/frontend/src/services/https/waterValue.ts
+++ b/frontend/src/services/https/waterValue.ts
@@ -10,15 +10,17 @@ interface MeterParams {
 
 export async function GetAllWaterUsageLogs() {
     return await axios
-        .get(`${apiUrl}/waterusages`, authHeader())
+        .get(`${apiUrl}/water-values`, authHeader())
         .then((res) => res)
         .catch((e) => e.response);
 }
 
-export async function GetWaterValues(deviceId?: number, statusId?: number) {
-    const params: Record<string, number> = {};
+export async function GetWaterValues(deviceId?: number, statusId?: number, startDate?: string, endDate?: string) {
+    const params: Record<string, string | number> = {};
     if (deviceId != null) params.device_id = deviceId;
     if (statusId != null) params.status_id = statusId;
+    if (startDate) params.start_date = startDate;
+    if (endDate) params.end_date = endDate;
     return await axios
         .get(`${apiUrl}/water-values`, { ...authHeader(), params })
         .then((res) => res)
@@ -127,4 +129,37 @@ export async function DeleteWaterValueById(id: string) {
         .delete(`${apiUrl}/watervalue/${id}`, authHeader())
         .then((res) => res)
         .catch((e) => e.response);
+}
+
+export async function CreateWaterValue(data: {
+    meter_value: number;
+    device_id: number;
+    timestamp?: string;
+    note?: string;
+}) {
+    return await axios
+        .post(`${apiUrl}/water-values`, data, authHeader())
+        .then((res) => res)
+        .catch((e: AxiosError) => e.response);
+}
+
+export async function CreateWaterValueManual(data: {
+    meter_value: number;
+    device_id: number;
+    timestamp?: string;
+    note?: string;
+    image?: File;
+}) {
+    const form = new FormData();
+    form.append("meter_value", String(data.meter_value));
+    form.append("device_id", String(data.device_id));
+    if (data.timestamp) form.append("timestamp", data.timestamp);
+    if (data.note)      form.append("note", data.note);
+    if (data.image)     form.append("image", data.image);
+    return await axios
+        .post(`${apiUrl}/water-values/manual`, form, {
+            headers: { ...authHeader().headers, "Content-Type": "multipart/form-data" },
+        })
+        .then((res) => res)
+        .catch((e: AxiosError) => e.response);
 }


### PR DESCRIPTION
…ashboard, and access controls

Backend:
- POST /water-values/manual: multipart endpoint to create auto-approved (status=2) readings with image upload
- POST /maintain-logs/report: multipart endpoint for users to report problems with image upload, sends notification
- Fix maintain log status not updating: use Omit(Status,Location).Save() in repository to prevent GORM FK normalization from preloaded associations overwriting explicit StatusID changes
- Guard: block editing/deleting maintain logs with status=solved
- Guard: block editing/deleting users with role_id=1 (admin) in service and AdminDeleteUser handler

Frontend:
- WaterDetail: add เพิ่มค่ามิเตอร์ modal with image upload; image column before date column in readings table
- MeterMap: add reading creation from map popup (modal outside MapContainer to avoid Leaflet DOM isolation); role-gated to Admin/Engineer
- Water (dashboard): full building overview with bar chart, stats cards, trend arrows, per-building usage grid
- NotiMaintainPage: problem reporting form with preset chips, image upload, success screen
- MaintainLogPage: show images in table/cards; lock edit button for solved logs (Lock icon); lock edit+delete for admin users
- UserPage: lock edit+delete buttons for admin role users (role_id=1)